### PR TITLE
feat(layout): 글로벌 네비게이션 바 UI 수정 (데이터가 없는 경우)

### DIFF
--- a/app/_components/layout/FollowingDropdown.tsx
+++ b/app/_components/layout/FollowingDropdown.tsx
@@ -70,6 +70,8 @@ export default function FollowingDropdown({ userId }: FollowingDropdownProps) {
     );
   }
 
+  const hasNoFollowingArtists = Number(data.totalFollowings) === 0;
+
   return (
     <DropdownMenu onOpenChange={() => setIsSelected((prev) => !prev)}>
       <DropdownMenuTrigger
@@ -82,14 +84,12 @@ export default function FollowingDropdown({ userId }: FollowingDropdownProps) {
       </DropdownMenuTrigger>
       <DropdownMenuContent className="bg-custom-background border-custom-gray-100 z-10 w-108.5 translate-x-43 translate-y-[13px] rounded-none border p-0 shadow-none">
         <div className="text-custom-brand-primary h-11.5 border-b-1 px-5 py-3 text-sm font-medium">
-          {Number(data.totalFollowings) === 0
-            ? '팔로잉 중인 작가가 없습니다.'
-            : `팔로잉 작가 (${formatNumberWithComma(data.totalFollowings)})`}
+          팔로잉 작가 ({formatNumberWithComma(data.totalFollowings)})
         </div>
 
-        {Number(data.totalFollowings) === 0 ? (
-          <div className="text-custom-gray-300 flex h-60 w-full items-center justify-center text-sm">
-            팔로잉 중인 작가가 없습니다.
+        {hasNoFollowingArtists ? (
+          <div className="text-custom-gray-200 flex h-35 w-full items-center justify-center text-xs">
+            팔로잉 중인 작가가 없습니다
           </div>
         ) : (
           data.followings.map((artist: any) => (
@@ -113,14 +113,16 @@ export default function FollowingDropdown({ userId }: FollowingDropdownProps) {
           ))
         )}
 
-        <div className="flex h-21.5 w-full items-center justify-center border-t-1">
-          <Link
-            href={`${ROUTE_PATHS.FOLLOWING_CREATORS}`}
-            className="bg-custom-brand-secondary text-custom-button-text flex h-11.5 w-46 items-center justify-center rounded-full text-sm font-medium"
-          >
-            팔로잉 작가 모두보기
-          </Link>
-        </div>
+        {!hasNoFollowingArtists && (
+          <div className="flex h-21.5 w-full items-center justify-center border-t-1">
+            <Link
+              href={`${ROUTE_PATHS.FOLLOWING_CREATORS}`}
+              className="bg-custom-brand-secondary text-custom-button-text flex h-11.5 w-46 items-center justify-center rounded-full text-sm font-medium"
+            >
+              팔로잉 작가 모두보기
+            </Link>
+          </div>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/app/_components/layout/FollowingPopover.tsx
+++ b/app/_components/layout/FollowingPopover.tsx
@@ -4,12 +4,7 @@ import { useEffect, useState } from 'react';
 
 import Link from 'next/link';
 
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { ROUTE_PATHS } from '@/constants';
 import { AddIcon, CheckIcon } from '@/lib/icons';
 import { followingPreviewMock } from '@/lib/mocks/following-preview.mock';
@@ -18,39 +13,28 @@ import { formatNumberWithComma } from '@/utils/formatNumber';
 
 import ProfileImage from '../shared/ProfileImage';
 
-interface FollowingDropdownProps {
+interface FollowingPopoverProps {
   userId: string | null;
 }
 
-// TODO: 유저 데이터 연동 시, userId 값 수정 필요 및 isLoggedIn을 별도로 사용하지 않고 userId를 null로 사용?
-export default function FollowingDropdown({ userId }: FollowingDropdownProps) {
-  const [isSelected, setIsSelected] = useState(false);
+export default function FollowingPopover({ userId }: FollowingPopoverProps) {
+  const [isOpen, setIsOpen] = useState(false);
   const [followStates, setFollowStates] = useState<Record<string, boolean>>({});
 
-  // TODO: API 연동 시 데이터 타입 정의 필요
   const data = followingPreviewMock;
 
-  // TODO: 유저 로그인 유도 CTA 확정 시 수정 필요
-  // 비로그인 유저 클릭 대응
   const handleUnauthenticatedUser = () => {
     alert('로그인 해라');
   };
 
-  // TODO: 언팔로우 api 요청 필요, debounce 적용 필요
-  // 팔로우 상태 토글
   const handleFollowButtonClick = (id: string) => {
     setFollowStates((prev) => ({ ...prev, [id]: !prev[id] }));
   };
 
-  // TODO: api 요청에서 받아온 data와 연동시 deps에 `data` 추가
-  // 최초 data를 기준으로 followStates를 초기화, api 에서 받아오는 데이터 이므로 useEffect 사용
   useEffect(() => {
-    console.log(data);
-
     if (!data || !data.totalFollowings) return;
 
     const initialState: Record<string, boolean> = {};
-
     data.followings.forEach((artist: any) => {
       initialState[artist.artistId] = true;
     });
@@ -58,7 +42,6 @@ export default function FollowingDropdown({ userId }: FollowingDropdownProps) {
     setFollowStates(initialState);
   }, [data]);
 
-  // 비로그인일 경우 버튼만 보여줌 (Dropdown X), 클릭 시 로그인 유도
   if (!userId) {
     return (
       <button
@@ -73,27 +56,27 @@ export default function FollowingDropdown({ userId }: FollowingDropdownProps) {
   const hasNoFollowingArtists = Number(data.totalFollowings) === 0;
 
   return (
-    <DropdownMenu onOpenChange={() => setIsSelected((prev) => !prev)}>
-      <DropdownMenuTrigger
+    <Popover open={isOpen} onOpenChange={setIsOpen}>
+      <PopoverTrigger
         className={cn(
           'cursor-pointer text-sm font-medium underline-offset-2 hover:underline',
-          isSelected && 'underline'
+          isOpen && 'underline'
         )}
       >
         팔로잉 작가
-      </DropdownMenuTrigger>
-      <DropdownMenuContent className="bg-custom-background border-custom-gray-100 z-10 w-108.5 translate-x-43 translate-y-[13px] rounded-none border p-0 shadow-none">
+      </PopoverTrigger>
+      <PopoverContent className="bg-custom-background border-custom-gray-100 z-10 w-108.5 translate-x-43 translate-y-[13px] rounded-none border p-0 shadow-none">
         <div className="text-custom-brand-primary h-11.5 border-b-1 px-5 py-3 text-sm font-medium">
           팔로잉 작가 ({formatNumberWithComma(data.totalFollowings)})
         </div>
 
         {hasNoFollowingArtists ? (
           <div className="text-custom-gray-200 flex h-35 w-full items-center justify-center text-xs">
-            팔로잉 중인 작가가 없습니다
+            팔로잉 중인 작가가 없습니다.
           </div>
         ) : (
           data.followings.map((artist: any) => (
-            <DropdownMenuItem
+            <div
               key={artist.artistId}
               className="text-custom-brand-primary hover:text-custom-brand-primary focus:text-custom-brand-primary flex h-17 w-full items-center justify-between px-5 text-sm font-medium hover:bg-transparent focus:bg-transparent"
             >
@@ -109,7 +92,7 @@ export default function FollowingDropdown({ userId }: FollowingDropdownProps) {
                 isFollowing={followStates[artist.artistId]}
                 onFollowButtonClick={() => handleFollowButtonClick(artist.artistId)}
               />
-            </DropdownMenuItem>
+            </div>
           ))
         )}
 
@@ -123,8 +106,8 @@ export default function FollowingDropdown({ userId }: FollowingDropdownProps) {
             </Link>
           </div>
         )}
-      </DropdownMenuContent>
-    </DropdownMenu>
+      </PopoverContent>
+    </Popover>
   );
 }
 
@@ -134,25 +117,19 @@ interface FollowingButtonProps {
 }
 
 function FollowingButton({ isFollowing, onFollowButtonClick }: FollowingButtonProps) {
-  const handleFollowButtonClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-
-    onFollowButtonClick();
-  };
-
   return (
     <div className="relative">
       {isFollowing ? (
         <button
-          onClick={handleFollowButtonClick}
-          className="border-custom-gray-100 flex h-9.5 w-24 cursor-pointer items-center justify-center gap-1.5 rounded-full border text-sm"
+          onClick={onFollowButtonClick}
+          className="border-custom-gray-100 bg-custom-ivory-100 flex h-9.5 w-24 cursor-pointer items-center justify-center gap-1.5 rounded-full border text-sm"
         >
           <CheckIcon className="!h-6 !w-6" />
           <span>팔로잉</span>
         </button>
       ) : (
         <button
-          onClick={handleFollowButtonClick}
+          onClick={onFollowButtonClick}
           className="border-custom-gray-100 flex h-9.5 w-24 cursor-pointer items-center justify-center gap-1.5 rounded-full border text-sm"
         >
           <AddIcon className="!h-6 !w-6" />

--- a/app/_components/layout/GlobalNavBar.tsx
+++ b/app/_components/layout/GlobalNavBar.tsx
@@ -2,17 +2,17 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { ROUTE_PATHS } from '@/constants';
-import { BookmarkIcon, NotificationIcon, NotificationUnreadIcon } from '@/lib/icons';
+import { BookmarkIcon } from '@/lib/icons';
 
 import CategoryDropdown from './CategoryDropdown';
 import FollowingDropdown from './FollowingDropdown';
+import NotificationPopover from './NotificationPopover';
 import SearchBar from './SearchBar';
 import UserProfileDropdown from './UserProfileDropdown';
 
 // TODO: 유저 기능 연동 필요
 export default function GlobalNavBar() {
   const userId: string | null = '21919299';
-  const hasUnreadNotification = false;
 
   return (
     <header className="border-custom-gray-100 bg-custom-background absolute inset-x-0 top-0 z-50 h-14 border-b">
@@ -48,13 +48,7 @@ export default function GlobalNavBar() {
                   </Link>
                 </li>
                 <li className="h-9.5 w-9.5">
-                  <button className="flex h-9.5 w-9.5 cursor-pointer items-center justify-center">
-                    {hasUnreadNotification ? (
-                      <NotificationUnreadIcon className="h-6 w-6" />
-                    ) : (
-                      <NotificationIcon className="h-6 w-6" />
-                    )}
-                  </button>
+                  <NotificationPopover />
                 </li>
               </ul>
 

--- a/app/_components/layout/GlobalNavBar.tsx
+++ b/app/_components/layout/GlobalNavBar.tsx
@@ -5,7 +5,7 @@ import { ROUTE_PATHS } from '@/constants';
 import { BookmarkIcon } from '@/lib/icons';
 
 import CategoryDropdown from './CategoryDropdown';
-import FollowingDropdown from './FollowingDropdown';
+import FollowingPopover from './FollowingPopover';
 import NotificationPopover from './NotificationPopover';
 import SearchBar from './SearchBar';
 import UserProfileDropdown from './UserProfileDropdown';
@@ -26,7 +26,7 @@ export default function GlobalNavBar() {
               <CategoryDropdown />
             </li>
             <li>
-              <FollowingDropdown userId={userId} />
+              <FollowingPopover userId={userId} />
             </li>
           </ul>
         </div>

--- a/app/_components/layout/NotificationPopover.tsx
+++ b/app/_components/layout/NotificationPopover.tsx
@@ -1,0 +1,30 @@
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { NotificationIcon, NotificationUnreadIcon } from '@/lib/icons';
+
+export default function NotificationPopover() {
+  const hasUnreadNotification = false;
+
+  return (
+    <Popover>
+      <PopoverTrigger className="flex h-9.5 w-9.5 cursor-pointer items-center justify-center">
+        {hasUnreadNotification ? (
+          <NotificationUnreadIcon className="h-6 w-6" />
+        ) : (
+          <NotificationIcon className="h-6 w-6" />
+        )}
+      </PopoverTrigger>
+      <PopoverContent className="bg-custom-background border-custom-gray-100 z-10 w-80 -translate-x-20 translate-y-1 rounded-none border p-0 shadow-none">
+        <div className="flex h-11.5 w-full items-center justify-between border-b px-5">
+          <h3 className="text-custom-brand-primary text-sm font-medium">읽지 않은 알림 (0)</h3>
+          <button className="text-custom-brand-primary cursor-pointer text-xs font-semibold underline underline-offset-2">
+            모두 읽음
+          </button>
+        </div>
+
+        <div className="text-custom-gray-200 flex h-35 w-full items-center justify-center text-xs">
+          새로운 알림이 없습니다
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import * as React from 'react';
+
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+
+import { cn } from '@/lib/utils';
+
+function Popover({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
+
+function PopoverTrigger({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
+
+function PopoverContent({
+  className,
+  align = 'center',
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden',
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  );
+}
+
+function PopoverAnchor({ ...props }: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />;
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.7",
     "@radix-ui/react-dropdown-menu": "^2.1.12",
+    "@radix-ui/react-popover": "^1.1.11",
     "@radix-ui/react-slot": "^1.2.0",
     "@tanstack/react-query": "^5.72.2",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.12
         version: 2.1.12(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-popover':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slot':
         specifier: ^1.2.0
         version: 1.2.0(@types/react@19.1.1)(react@19.1.0)
@@ -1108,6 +1111,19 @@ packages:
 
   '@radix-ui/react-menu@2.1.12':
     resolution: {integrity: sha512-+qYq6LfbiGo97Zz9fioX83HCiIYYFNs8zAsVCMQrIakoNYylIzWuoD/anAD3UzvvR6cnswmfRFJFq/zYYq/k7Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popover@1.1.11':
+    resolution: {integrity: sha512-yFMfZkVA5G3GJnBgb2PxrrcLKm1ZLWXrbYVgdyTl//0TYEIHS9LJbnyz7WWcZ0qCq7hIlJZpRtxeSeIG5T5oJw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -4573,6 +4589,29 @@ snapshots:
       '@radix-ui/react-roving-focus': 1.1.7(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-slot': 1.2.0(@types/react@19.1.1)(react@19.1.0)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.1)(react@19.1.0)
+      aria-hidden: 1.2.4
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.6.3(@types/react@19.1.1)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.1
+      '@types/react-dom': 19.1.2(@types/react@19.1.1)
+
+  '@radix-ui/react-popover@1.1.11(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.1)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.1)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.7(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.2(@types/react@19.1.1)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.4(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.1)(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.4(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.6(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.0(@types/react-dom@19.1.2(@types/react@19.1.1))(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.0(@types/react@19.1.1)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.1)(react@19.1.0)
       aria-hidden: 1.2.4
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)


### PR DESCRIPTION
## 🔧 작업 내용
1. 팔로잉 작가가 없는 경우에 대한 디자인을 수정하였습니다.

2. 알림 버튼을 눌렀을때 popover가 나오도록 NotifiationPopover를 추가하였습니다.
- shadcn/ui popover 설치
- 알림 없음 UI 추가

3. 팔로잉 작가 부분을 Dropdown에서 Popover로 리팩토링 하였습니다.

## 📸 스크린샷 (선택)

- 팔로잉 작가가 없는 경우
![화면 캡처 2025-04-27 010323](https://github.com/user-attachments/assets/e21e9135-00f4-497b-8d06-bd1f48990263)

- 알림 버튼을 눌렀을 때
![화면 캡처 2025-04-27 013447](https://github.com/user-attachments/assets/96c621fc-59e4-4bbe-b151-d16ba27cb164)
