### PR TITLE
feat(proxy): next config의 rewirtes를 사용한 proxy 설정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_API_URL=API_요청에_사용되는_URL

--- a/app/(routes)/products/_components/ProductsGrid.tsx
+++ b/app/(routes)/products/_components/ProductsGrid.tsx
@@ -3,7 +3,7 @@ import { redirect } from 'next/navigation';
 import InfiniteProductsGrid from '@/app/_components/product/InfiniteProductsGrid';
 import ProductCard from '@/app/_components/product/ProductCard';
 import { ROUTE_PATHS } from '@/constants';
-import { fetchProductsList } from '@/lib/apis/products.api';
+import { fetchProductsListServerSide } from '@/lib/apis/products.api';
 import { ProductsListQueryParams } from '@/lib/apis/products.type';
 
 interface ProductsGridProps {
@@ -11,7 +11,7 @@ interface ProductsGridProps {
 }
 
 export default async function ProductsGrid({ queryParams }: ProductsGridProps) {
-  const data = await fetchProductsList({ ...queryParams, limit: 20 });
+  const data = await fetchProductsListServerSide({ ...queryParams, limit: 20 });
   const products = data.result.items;
 
   const hasOnlyKeyword =

--- a/app/(routes)/products/category/[category_value]/_components/ProductsGrid.tsx
+++ b/app/(routes)/products/category/[category_value]/_components/ProductsGrid.tsx
@@ -1,6 +1,6 @@
 import InfiniteProductsGrid from '@/app/_components/product/InfiniteProductsGrid';
 import ProductCard from '@/app/_components/product/ProductCard';
-import { fetchProductsList } from '@/lib/apis/products.api';
+import { fetchProductsListServerSide } from '@/lib/apis/products.api';
 import { ProductsListQueryParams } from '@/lib/apis/products.type';
 
 interface ProductsGridProps {
@@ -8,7 +8,7 @@ interface ProductsGridProps {
 }
 
 export default async function ProductsGrid({ queryParams }: ProductsGridProps) {
-  const data = await fetchProductsList({ ...queryParams, limit: 20 });
+  const data = await fetchProductsListServerSide({ ...queryParams, limit: 20 });
   const products = data.result.items;
 
   return (

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,3 +1,4 @@
 // 상수명 중복을 방지하고 모듈 관리를 위해 index.ts에서 re-export 합니다.
 export * from './items';
 export * from './route-paths';
+export * from './url';

--- a/constants/url.ts
+++ b/constants/url.ts
@@ -1,0 +1,4 @@
+export const API_BASE_URL = {
+  SERVER_SIDE: 'http://211.188.54.19:8000',
+  CLIENT_SIDE: '/proxy',
+};

--- a/constants/url.ts
+++ b/constants/url.ts
@@ -1,4 +1,4 @@
 export const API_BASE_URL = {
-  SERVER_SIDE: 'http://211.188.54.19:8000',
-  CLIENT_SIDE: '/proxy',
+  SERVER: 'http://211.188.54.19:8000',
+  CLIENT: '/proxy',
 };

--- a/lib/apis/products.api.ts
+++ b/lib/apis/products.api.ts
@@ -6,15 +6,9 @@ import { ProductsListQueryParams, ProductsListResponse } from './products.type';
 export const fetchProductsList = async (
   queryParams: ProductsListQueryParams
 ): Promise<ProductsListResponse> => {
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
-
-  if (!baseUrl) {
-    throw new Error('API URL이 환경변수에 정의되어 있지 않습니다.');
-  }
-
   const queryString = createQueryParams(queryParams);
 
-  const res = await fetch(`${baseUrl}/api/v1/items/search?${queryString}`, {
+  const res = await fetch(`http://211.188.54.19:8000/api/v1/items/search?${queryString}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -34,12 +28,6 @@ export const fetchProductsList = async (
 export const fetchClientProductsList = async (
   queryParams: ProductsListQueryParams
 ): Promise<ProductsListResponse> => {
-  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
-
-  if (!baseUrl) {
-    throw new Error('API URL이 환경변수에 정의되어 있지 않습니다.');
-  }
-
   const queryString = createQueryParams(queryParams);
 
   const res = await fetch(`/proxy/api/v1/items/search?${queryString}`, {

--- a/lib/apis/products.api.ts
+++ b/lib/apis/products.api.ts
@@ -26,5 +26,5 @@ const createProductsListFetcher = (baseUrl: string) => {
   };
 };
 
-export const fetchProductsListServerSide = createProductsListFetcher(API_BASE_URL.SERVER_SIDE);
-export const fetchProductsListClientSide = createProductsListFetcher(API_BASE_URL.CLIENT_SIDE);
+export const fetchProductsListServerSide = createProductsListFetcher(API_BASE_URL.SERVER);
+export const fetchProductsListClientSide = createProductsListFetcher(API_BASE_URL.CLIENT);

--- a/lib/apis/products.api.ts
+++ b/lib/apis/products.api.ts
@@ -1,48 +1,30 @@
+import { API_BASE_URL } from '@/constants/url';
 import { createQueryParams } from '@/utils/queryParams';
 
 import { ErrorResponse } from './common.type';
 import { ProductsListQueryParams, ProductsListResponse } from './products.type';
 
-export const fetchProductsList = async (
-  queryParams: ProductsListQueryParams
-): Promise<ProductsListResponse> => {
-  const queryString = createQueryParams(queryParams);
+const createProductsListFetcher = (baseUrl: string) => {
+  return async (queryParams: ProductsListQueryParams): Promise<ProductsListResponse> => {
+    const queryString = createQueryParams(queryParams);
 
-  const res = await fetch(`http://211.188.54.19:8000/api/v1/items/search?${queryString}`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    cache: 'no-store',
-  });
+    const res = await fetch(`${baseUrl}/api/v1/items/search?${queryString}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      cache: 'no-store',
+    });
 
-  const data = await res.json();
+    const data = await res.json();
 
-  if (!res.ok) {
-    throw data as ErrorResponse;
-  }
+    if (!res.ok) {
+      throw data as ErrorResponse;
+    }
 
-  return data as ProductsListResponse;
+    return data as ProductsListResponse;
+  };
 };
 
-export const fetchClientProductsList = async (
-  queryParams: ProductsListQueryParams
-): Promise<ProductsListResponse> => {
-  const queryString = createQueryParams(queryParams);
-
-  const res = await fetch(`/proxy/api/v1/items/search?${queryString}`, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    cache: 'no-store',
-  });
-
-  const data = await res.json();
-
-  if (!res.ok) {
-    throw data as ErrorResponse;
-  }
-
-  return data as ProductsListResponse;
-};
+export const fetchProductsListServerSide = createProductsListFetcher(API_BASE_URL.SERVER_SIDE);
+export const fetchProductsListClientSide = createProductsListFetcher(API_BASE_URL.CLIENT_SIDE);

--- a/lib/apis/products.api.ts
+++ b/lib/apis/products.api.ts
@@ -1,4 +1,4 @@
-import { API_BASE_URL } from '@/constants/url';
+import { API_BASE_URL } from '@/constants';
 import { createQueryParams } from '@/utils/queryParams';
 
 import { ErrorResponse } from './common.type';

--- a/lib/apis/products.api.ts
+++ b/lib/apis/products.api.ts
@@ -30,3 +30,31 @@ export const fetchProductsList = async (
 
   return data as ProductsListResponse;
 };
+
+export const fetchClientProductsList = async (
+  queryParams: ProductsListQueryParams
+): Promise<ProductsListResponse> => {
+  const baseUrl = process.env.NEXT_PUBLIC_API_URL;
+
+  if (!baseUrl) {
+    throw new Error('API URL이 환경변수에 정의되어 있지 않습니다.');
+  }
+
+  const queryString = createQueryParams(queryParams);
+
+  const res = await fetch(`/proxy/api/v1/items/search?${queryString}`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    cache: 'no-store',
+  });
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw data as ErrorResponse;
+  }
+
+  return data as ProductsListResponse;
+};

--- a/lib/queries/useProductsQueries.ts
+++ b/lib/queries/useProductsQueries.ts
@@ -1,6 +1,6 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-import { fetchClientProductsList, fetchProductsList } from '../apis/products.api';
+import { fetchProductsListClientSide } from '../apis/products.api';
 import { ProductsListQueryParams } from '../apis/products.type';
 
 import { QUERY_KEYS } from './queryKeys';
@@ -12,7 +12,7 @@ export const useProductsInfiniteQuery = (
   return useInfiniteQuery({
     queryKey: QUERY_KEYS.products.list(queryParams),
     queryFn: ({ pageParam = 2 }) =>
-      fetchClientProductsList({ ...queryParams, page: pageParam, limit: 20 }),
+      fetchProductsListClientSide({ ...queryParams, page: pageParam, limit: 20 }),
     getNextPageParam: (lastPage) => {
       const { meta } = lastPage.result;
       return meta.hasNextPage ? meta.currentPage + 1 : undefined;

--- a/lib/queries/useProductsQueries.ts
+++ b/lib/queries/useProductsQueries.ts
@@ -1,6 +1,6 @@
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-import { fetchProductsList } from '../apis/products.api';
+import { fetchClientProductsList, fetchProductsList } from '../apis/products.api';
 import { ProductsListQueryParams } from '../apis/products.type';
 
 import { QUERY_KEYS } from './queryKeys';
@@ -12,7 +12,7 @@ export const useProductsInfiniteQuery = (
   return useInfiniteQuery({
     queryKey: QUERY_KEYS.products.list(queryParams),
     queryFn: ({ pageParam = 2 }) =>
-      fetchProductsList({ ...queryParams, page: pageParam, limit: 20 }),
+      fetchClientProductsList({ ...queryParams, page: pageParam, limit: 20 }),
     getNextPageParam: (lastPage) => {
       const { meta } = lastPage.result;
       return meta.hasNextPage ? meta.currentPage + 1 : undefined;

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,15 @@ const nextConfig: NextConfig = {
     domains: ['fastly.picsum.photos', 'kr.object.ncloudstorage.com'],
   },
 
+  async rewrites() {
+    return [
+      {
+        source: '/proxy/:path*',
+        destination: `http://211.188.54.19:8000/:path*`,
+      },
+    ];
+  },
+
   reactStrictMode: true,
   webpack: (config) => {
     config.module.rules.push({


### PR DESCRIPTION
## 🔧 작업 내용

1. next config의 rewrites를 사용하여 proxy를 설정하였습니다.
- 클라이언트 로직에서는 배포 환경에서 mixed-content 에러를 방지하기 위해 `API_BASE_URL.CLIENT`를 사용해주세요!!
- 서버 사이드 로직에서는 평상시의 base url인 `API_BASE_URL.SERVER`를 사용해주세요!!
- https://github.com/swyp-9-web/indi-front/pull/25/commits/156a80c705c80fb2bccabe80828e15272b57bfcc 커밋의 `products.api.ts` 파일을 통해 예시를 확인해주세요..!


