### PR TITLE
refactor(ci): vercel 테스트 배포 워크플로우 수정 (dev/main 모두 production으로 배포)

### DIFF
--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -36,17 +36,7 @@ jobs:
         run: pnpm vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Build Project Artifacts
-        run: |
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            pnpm vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-          else
-            pnpm vercel build --token=${{ secrets.VERCEL_TOKEN }}
-          fi
+        run: pnpm vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy Project Artifacts to Vercel
-        run: |
-          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
-            pnpm vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} --yes --prod
-          else
-            pnpm vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} --yes
-          fi
+        run: pnpm vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }} --yes --prod


### PR DESCRIPTION
## 🔧 작업 내용

1. 기존의 PR preview의 경우에는 변동사항 없으나, main을 production / dev를 preview로 배포하던 기존 시스템에서
네이버 OAuth 콜백 url 제한으로 인해 dev 또한 production으로 배포하게 되었습니다.
