### PR TITLE
feat(scrap): 스크랩 작품 목록 페이지 구현

### DIFF
--- a/app/(routes)/mypage/scrap/_components/NoScrapProducts.tsx
+++ b/app/(routes)/mypage/scrap/_components/NoScrapProducts.tsx
@@ -1,0 +1,10 @@
+export default function NoResults() {
+  return (
+    <div className="mt-40 flex flex-col items-center justify-center">
+      <h2 className="text-custom-brand-primary mt-4 mb-6 text-center text-2xl font-bold">
+        스크랩한 작품이 없습니다.
+      </h2>
+      <p className="text-custom-gray-400 text-sm">더 많은 작품을 확인해보세요!</p>
+    </div>
+  );
+}

--- a/app/(routes)/mypage/scrap/_components/ProductsControls.tsx
+++ b/app/(routes)/mypage/scrap/_components/ProductsControls.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+
+import CombinedToggleGroup from '@/app/_components/filter/CombinedToggleGroup';
+import SortDropdown from '@/app/_components/filter/SortDropdown';
+import { SCRAP_SORT_ITEMS } from '@/constants';
+
+export default function ProductsControls() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const buildCategoryQuery = (value: string[]) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.delete('categoryTypes');
+    value.forEach((category) => params.append('categoryTypes', category));
+
+    return params.toString();
+  };
+
+  const buildSizeQuery = (value: string[]) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.delete('sizeTypes');
+    value.forEach((size) => params.append('sizeTypes', size));
+
+    return params.toString();
+  };
+
+  const buildSortQuery = (value: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.delete('sortType');
+    params.append('sortType', value);
+
+    return params.toString();
+  };
+
+  const handleSizeChange = (value: string[]) => {
+    const query = buildSizeQuery(value);
+
+    router.replace(query ? `${pathname}?${query}` : pathname);
+  };
+
+  const handleCategoryChange = (value: string[]) => {
+    const query = buildCategoryQuery(value);
+
+    router.replace(query ? `${pathname}?${query}` : pathname);
+  };
+
+  const handleDropdownItemSelected = (item: { label: string; value: string }) => {
+    const query = buildSortQuery(item.value);
+
+    router.replace(query ? `${pathname}?${query}` : pathname);
+  };
+
+  const handleRefreshButtonClick = () => {
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.delete('categoryTypes');
+    params.delete('sizeTypes');
+
+    const query = params.toString();
+
+    router.replace(query ? `${pathname}?${query}` : pathname);
+  };
+
+  return (
+    <>
+      <CombinedToggleGroup
+        onCategoryChange={handleCategoryChange}
+        onSizeChange={handleSizeChange}
+        onRefreshButtonClick={handleRefreshButtonClick}
+      />
+
+      <div className="ml-auto">
+        <SortDropdown items={SCRAP_SORT_ITEMS} onSelect={handleDropdownItemSelected} />
+      </div>
+    </>
+  );
+}

--- a/app/(routes)/mypage/scrap/_components/ProductsGrid.tsx
+++ b/app/(routes)/mypage/scrap/_components/ProductsGrid.tsx
@@ -1,0 +1,32 @@
+import InfiniteProductsGrid from '@/app/_components/product/InfiniteProductsGrid';
+import ProductCard from '@/app/_components/product/ProductCard';
+import { fetchProductsList } from '@/lib/apis/products.api';
+import { ProductsListQueryParams } from '@/lib/apis/products.type';
+
+import NoScrapProducts from './NoScrapProducts';
+
+interface ProductsGridProps {
+  queryParams: ProductsListQueryParams;
+}
+
+export default async function ProductsGrid({ queryParams }: ProductsGridProps) {
+  const data = await fetchProductsList({
+    sortType: 'SCRAP_ITEM_RECENT',
+    ...queryParams,
+    limit: 20,
+  });
+  const products = data.result.items;
+
+  if (products.length === 0) return <NoScrapProducts />;
+
+  return (
+    <>
+      <div className="mb-10 flex flex-wrap gap-x-5 gap-y-10">
+        {products.map((product) => (
+          <ProductCard hasScrapCount key={product.id} product={product} />
+        ))}
+      </div>
+      {data.result.meta.hasNextPage && <InfiniteProductsGrid queryParams={queryParams} />}
+    </>
+  );
+}

--- a/app/(routes)/mypage/scrap/page.tsx
+++ b/app/(routes)/mypage/scrap/page.tsx
@@ -1,0 +1,34 @@
+import { Suspense } from 'react';
+
+import ProductsControls from './_components/ProductsControls';
+import ProductsGrid from './_components/ProductsGrid';
+
+interface MyScrapPageProps {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+export default async function MyScrap({ searchParams }: MyScrapPageProps) {
+  const queryParams = await searchParams;
+
+  return (
+    <main className="w-8xl mx-auto mt-25 px-20">
+      <h2 className="text-custom-brand-primary text-2xl font-bold">스크랩 한 작품</h2>
+
+      <div className="mt-5 mb-4.5 flex flex-col gap-4">
+        <ProductsControls />
+      </div>
+
+      <section>
+        <Suspense
+          fallback={
+            <div className="mt-25 flex items-center justify-center">
+              <div className="border-custom-gray-200 h-12 w-12 animate-spin rounded-full border-4 border-t-transparent" />
+            </div>
+          }
+        >
+          <ProductsGrid queryParams={queryParams} />
+        </Suspense>
+      </section>
+    </main>
+  );
+}

--- a/app/(routes)/products/_components/NoResults.tsx
+++ b/app/(routes)/products/_components/NoResults.tsx
@@ -6,7 +6,7 @@ interface NoResultsProps {
 
 export default function NoResults({ keyword }: NoResultsProps) {
   return (
-    <div className="w-8xl mx-auto mt-20 flex flex-col items-center justify-center">
+    <div className="mt-20 flex flex-col items-center justify-center">
       <FindInPageIcon />
       <h2 className="text-custom-brand-primary mt-4 mb-6 text-center text-2xl font-bold">
         &quot;{keyword}&quot;에 대한

--- a/app/(routes)/products/_components/ProductsGrid.tsx
+++ b/app/(routes)/products/_components/ProductsGrid.tsx
@@ -1,8 +1,5 @@
-import { redirect } from 'next/navigation';
-
 import InfiniteProductsGrid from '@/app/_components/product/InfiniteProductsGrid';
 import ProductCard from '@/app/_components/product/ProductCard';
-import { ROUTE_PATHS } from '@/constants';
 import { fetchProductsList } from '@/lib/apis/products.api';
 import { ProductsListQueryParams } from '@/lib/apis/products.type';
 

--- a/app/(routes)/products/category/[category_value]/page.tsx
+++ b/app/(routes)/products/category/[category_value]/page.tsx
@@ -24,7 +24,7 @@ export default async function ProductsCategory({ params, searchParams }: Categor
         {getCategoryLabelByValue(categoryValue)}
       </h2>
 
-      <div className="mt-4.5 mb-6 flex items-center justify-end">
+      <div className="mt-4.5 mb-4.5 flex items-center justify-end">
         <ProductsControls />
       </div>
 

--- a/app/(routes)/products/category/[category_value]/page.tsx
+++ b/app/(routes)/products/category/[category_value]/page.tsx
@@ -1,6 +1,5 @@
 import { Suspense } from 'react';
 
-import InfiniteProductsGrid from '@/app/_components/product/InfiniteProductsGrid';
 import ScrollToTopButton from '@/app/_components/shared/ScrollToTopButton';
 import { getCategoryLabelByValue } from '@/utils/item';
 

--- a/app/(routes)/products/page.tsx
+++ b/app/(routes)/products/page.tsx
@@ -22,7 +22,7 @@ export default async function Products({ searchParams }: ProductsPageProps) {
         &quot;{queryParams.keyword}&quot; 검색 결과
       </h2>
 
-      <div className="mt-5 mb-2 flex flex-col gap-4">
+      <div className="mt-5 mb-4.5 flex flex-col gap-4">
         <ProductsControls />
       </div>
 

--- a/constants/items.ts
+++ b/constants/items.ts
@@ -28,6 +28,6 @@ export const NORMAL_SORT_ITEMS = [
 ];
 
 export const SCRAP_SORT_ITEMS = [
-  { label: '최신 작품순', value: 'CREATED_RECENT' },
-  { label: '최신 스크랩순', value: 'SCRAPED_RECENT' },
+  { label: '최신 작품순', value: 'SCRAPED_RECENT' },
+  { label: '최신 스크랩순', value: 'SCRAP_ITEM_RECENT' },
 ];

--- a/constants/route-paths.ts
+++ b/constants/route-paths.ts
@@ -7,7 +7,7 @@ export const ROUTE_PATHS = {
   // 마이페이지
   MYPAGE: '/mypage',
   MY_FOLLOWING: '/mypage/following',
-  MY_SCRAPPED: '/mypage/products/scrap',
+  MY_SCRAPPED: '/mypage/scrap',
   DELETE_ACCOUNT: '/mypage/account/delete',
 
   // ARTIST_INVITE의 경우 로직에 따라 동적 라우팅이 아니라 쿼리를 이용해서 할 수도 있음

--- a/lib/apis/products.api.ts
+++ b/lib/apis/products.api.ts
@@ -1,6 +1,7 @@
 import { API_BASE_URL } from '@/constants';
 import { createQueryParams } from '@/utils/queryParams';
 
+import { fetchWithAuth } from './common.api';
 import { ErrorResponse } from './common.type';
 import { ProductsListQueryParams, ProductsListResponse } from './products.type';
 
@@ -12,7 +13,7 @@ export const fetchProductsList = async (
 
   const baseUrl = options.runtime === 'server' ? API_BASE_URL.SERVER : API_BASE_URL.CLIENT;
 
-  const res = await fetch(`${baseUrl}/api/v1/items/search?${queryString}`, {
+  const res = await fetchWithAuth(`${baseUrl}/api/v1/items/search?${queryString}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/utils/item.test.ts
+++ b/utils/item.test.ts
@@ -37,8 +37,8 @@ describe('Item 관련 유틸 함수 테스트', () => {
     it('label로 value를 가져온다', () => {
       expect(getSortValueByLabel('최신순')).toBe('CREATED_RECENT');
       expect(getSortValueByLabel('인기순')).toBe('SCRAPED_TOP');
-      expect(getSortValueByLabel('최신 작품순')).toBe('CREATED_RECENT');
-      expect(getSortValueByLabel('최신 스크랩순')).toBe('SCRAPED_RECENT');
+      expect(getSortValueByLabel('최신 작품순')).toBe('SCRAPED_RECENT');
+      expect(getSortValueByLabel('최신 스크랩순')).toBe('SCRAP_ITEM_RECENT');
     });
 
     it('없는 label을 넣으면 undefined를 반환한다', () => {


### PR DESCRIPTION
## 🔧 작업 내용

1. 스크랩 한 작품 목록을 확인할 수 있는 페이지를 구현하였습니다.
(검색 페이지와 유사, 아직 스크랩 기능이 구현이 되어있지 않아 스크랩 기능 구현 이후에 본격적인 동작 확인이 가능합니다.)

2. 스크랩 페이지 전용 sort item이 변경되었습니다. (`@/constants/items.ts`)

## 📸 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/71c86925-84ec-4faf-8ac2-fc3d3e104435)