### PR TITLE
feat(layout): 팔로잉 프리뷰 API 연동

### DIFF
--- a/app/(routes)/(main)/page.tsx
+++ b/app/(routes)/(main)/page.tsx
@@ -16,12 +16,10 @@ export default async function Home() {
     queryClient.prefetchQuery({
       queryKey: QUERY_KEYS.products.list({ page: 1, limit: 8, sortType: 'SCRAPED_TOP' }),
       queryFn: async () => await fetchProductsList({ page: 1, limit: 8, sortType: 'SCRAPED_TOP' }),
-      staleTime: 60 * 60 * 1000,
     }),
     queryClient.prefetchQuery({
       queryKey: QUERY_KEYS.products.list({ page: 1, limit: 8, sortType: 'REACTED_TOP' }),
       queryFn: async () => await fetchProductsList({ page: 1, limit: 8, sortType: 'REACTED_TOP' }),
-      staleTime: 60 * 60 * 1000,
     }),
   ]);
 

--- a/app/_components/layout/HeaderLeftSection/FollowingPopover.tsx
+++ b/app/_components/layout/HeaderLeftSection/FollowingPopover.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import Link from 'next/link';
 
@@ -8,7 +8,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 import { ROUTE_PATHS } from '@/constants';
 import { FollowingPreview } from '@/lib/apis/following.type';
 import { AddIcon, CheckIcon } from '@/lib/icons';
-import { followingPreviewMock } from '@/lib/mocks/following-preview.mock';
+import { useFollowingPreview } from '@/lib/queries/useFollowingQueries';
 import { useUserSummary } from '@/lib/queries/useUserQueries';
 import { cn } from '@/lib/utils';
 import { useAuthDialog } from '@/stores/useAuthDialog';
@@ -16,7 +16,6 @@ import { formatNumberWithComma } from '@/utils/formatNumber';
 
 import ProfileImage from '../../shared/ProfileImage';
 
-// TODO: 팔로잉 프리뷰 목록 API 연동 필요
 // TODO: 작가 팔로잉 및 팔로잉 취소 API 연동 필요
 export default function FollowingPopover() {
   const [isOpen, setIsOpen] = useState(false);
@@ -24,9 +23,9 @@ export default function FollowingPopover() {
   const { toggleIsOpen: toggleAuthDialogOpen } = useAuthDialog();
 
   const { data: user } = useUserSummary();
+  const { data: followingData } = useFollowingPreview();
 
-  const followingData = followingPreviewMock;
-  const artists = useMemo(() => followingData?.result.followingArtists ?? [], [followingData]);
+  const artists = followingData?.result.followingArtists ?? [];
   const followingCount = followingData?.result.totalFollowings ?? 0;
 
   const handleFollowToggle = (id: number) => {

--- a/lib/apis/following.api.ts
+++ b/lib/apis/following.api.ts
@@ -1,7 +1,7 @@
 import { API_BASE_URL } from '@/constants';
 
 import { fetchWithAuth } from './common.api';
-import { ErrorResponse } from './common.type';
+import { ErrorResponse, SuccessResponse } from './common.type';
 import { FollowingPreviewResponse } from './following.type';
 
 export const fetchFollowingPreview = async (
@@ -18,4 +18,32 @@ export const fetchFollowingPreview = async (
   }
 
   return data as FollowingPreviewResponse;
+};
+
+export const unfollowArtist = async (artistId: number) => {
+  const res = await fetchWithAuth(`${API_BASE_URL.CLIENT}/api/v1/follows/${artistId}`, {
+    method: 'DELETE',
+  });
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw data as ErrorResponse;
+  }
+
+  return data as SuccessResponse;
+};
+
+export const followArtist = async (artistId: number) => {
+  const res = await fetchWithAuth(`${API_BASE_URL.CLIENT}/api/v1/follows/${artistId}`, {
+    method: 'POST',
+  });
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw data as ErrorResponse;
+  }
+
+  return data as SuccessResponse;
 };

--- a/lib/apis/following.api.ts
+++ b/lib/apis/following.api.ts
@@ -1,0 +1,21 @@
+import { API_BASE_URL } from '@/constants';
+
+import { fetchWithAuth } from './common.api';
+import { ErrorResponse } from './common.type';
+import { FollowingPreviewResponse } from './following.type';
+
+export const fetchFollowingPreview = async (
+  options: { runtime: 'server' | 'client' } = { runtime: 'server' }
+): Promise<FollowingPreviewResponse> => {
+  const baseUrl = options.runtime === 'server' ? API_BASE_URL.SERVER : API_BASE_URL.CLIENT;
+
+  const res = await fetchWithAuth(`${baseUrl}/api/v1/follows/preview`);
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw data as ErrorResponse;
+  }
+
+  return data as FollowingPreviewResponse;
+};

--- a/lib/apis/following.type.ts
+++ b/lib/apis/following.type.ts
@@ -1,0 +1,14 @@
+import { SuccessResponse } from './common.type';
+
+export interface FollowingPreview {
+  id: number;
+  profileImgUrl: string;
+  nickname: string;
+}
+
+export interface FollowingPreviewResponse extends SuccessResponse {
+  result: {
+    totalFollowings: number;
+    followingArtists: FollowingPreview[];
+  };
+}

--- a/lib/mocks/following-preview.mock.ts
+++ b/lib/mocks/following-preview.mock.ts
@@ -1,28 +1,35 @@
-export const followingPreviewMock = {
-  totalFollowings: 1032,
-  followings: [
-    {
-      artistId: '23123123',
-      artistProfileImage:
-        'https://fastly.picsum.photos/id/18/2500/1667.jpg?hmac=JR0Z_jRs9rssQHZJ4b7xKF82kOj8-4Ackq75D_9Wmz8',
-      artistNickname: '신나는 작가',
-    },
-    {
-      artistId: '23123124',
-      artistProfileImage: null,
-      artistNickname: '즐거운 작가',
-    },
-    {
-      artistId: '23123125',
-      artistProfileImage:
-        'https://fastly.picsum.photos/id/18/2500/1667.jpg?hmac=JR0Z_jRs9rssQHZJ4b7xKF82kOj8-4Ackq75D_9Wmz8',
-      artistNickname: '공중제비 도는 작가',
-    },
-    {
-      artistId: '23123126',
-      artistProfileImage:
-        'https://fastly.picsum.photos/id/18/2500/1667.jpg?hmac=JR0Z_jRs9rssQHZJ4b7xKF82kOj8-4Ackq75D_9Wmz8',
-      artistNickname: '안녕하세요 작가',
-    },
-  ],
+import { FollowingPreviewResponse } from '../apis/following.type';
+
+export const followingPreviewMock: FollowingPreviewResponse = {
+  result: {
+    totalFollowings: 1032,
+    followingArtists: [
+      {
+        id: 23123123,
+        profileImgUrl:
+          'https://fastly.picsum.photos/id/18/2500/1667.jpg?hmac=JR0Z_jRs9rssQHZJ4b7xKF82kOj8-4Ackq75D_9Wmz8',
+        nickname: '신나는 작가',
+      },
+      {
+        id: 123123123,
+        profileImgUrl:
+          'https://fastly.picsum.photos/id/18/2500/1667.jpg?hmac=JR0Z_jRs9rssQHZJ4b7xKF82kOj8-4Ackq75D_9Wmz8',
+        nickname: '즐거운 작가',
+      },
+      {
+        id: 2132323322,
+        profileImgUrl:
+          'https://fastly.picsum.photos/id/18/2500/1667.jpg?hmac=JR0Z_jRs9rssQHZJ4b7xKF82kOj8-4Ackq75D_9Wmz8',
+        nickname: '공중제비 도는 작가',
+      },
+      {
+        id: 6213123123,
+        profileImgUrl:
+          'https://fastly.picsum.photos/id/18/2500/1667.jpg?hmac=JR0Z_jRs9rssQHZJ4b7xKF82kOj8-4Ackq75D_9Wmz8',
+        nickname: '안녕하세요 작가',
+      },
+    ],
+  },
+  resultCode: 200,
+  resultMessage: '성공',
 };

--- a/lib/queries/queryKeys.ts
+++ b/lib/queries/queryKeys.ts
@@ -3,8 +3,10 @@ import { stableStringify } from '@/utils/object';
 
 export const QUERY_KEYS = {
   products: {
-    all: ['products'],
     list: (queryParams: ProductsListQueryParams) => ['products', stableStringify(queryParams)],
+  },
+  following: {
+    preview: ['following', 'preview'],
   },
   user: {
     summary: ['user', 'summary'],

--- a/lib/queries/useFollowingQueries.ts
+++ b/lib/queries/useFollowingQueries.ts
@@ -1,6 +1,6 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useMutation, useQuery, UseQueryOptions } from '@tanstack/react-query';
 
-import { fetchFollowingPreview } from '../apis/following.api';
+import { fetchFollowingPreview, followArtist, unfollowArtist } from '../apis/following.api';
 import { FollowingPreviewResponse } from '../apis/following.type';
 
 import { QUERY_KEYS } from './queryKeys';
@@ -15,5 +15,13 @@ export const useFollowingPreview = (
     queryKey: QUERY_KEYS.following.preview,
     queryFn: () => fetchFollowingPreview({ runtime: 'client' }),
     ...options,
+  });
+};
+
+export const useToggleFollow = () => {
+  return useMutation({
+    mutationFn: async ({ artistId, isFollowing }: { artistId: number; isFollowing: boolean }) => {
+      return isFollowing ? await unfollowArtist(artistId) : await followArtist(artistId);
+    },
   });
 };

--- a/lib/queries/useFollowingQueries.ts
+++ b/lib/queries/useFollowingQueries.ts
@@ -1,0 +1,19 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+
+import { fetchFollowingPreview } from '../apis/following.api';
+import { FollowingPreviewResponse } from '../apis/following.type';
+
+import { QUERY_KEYS } from './queryKeys';
+
+export const useFollowingPreview = (
+  options?: Omit<
+    UseQueryOptions<FollowingPreviewResponse, Error, FollowingPreviewResponse>,
+    'queryKey' | 'queryFn'
+  >
+) => {
+  return useQuery({
+    queryKey: QUERY_KEYS.following.preview,
+    queryFn: () => fetchFollowingPreview({ runtime: 'client' }),
+    ...options,
+  });
+};

--- a/lib/queries/useUserQueries.ts
+++ b/lib/queries/useUserQueries.ts
@@ -22,6 +22,7 @@ export const useLoginCallback = () => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.user.summary });
+      queryClient.invalidateQueries({ predicate: (query) => query.queryKey[0] === 'products' });
     },
   });
 };
@@ -58,6 +59,7 @@ export const useLogout = () => {
     mutationFn: logoutUser,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: QUERY_KEYS.user.summary });
+      queryClient.invalidateQueries({ predicate: (query) => query.queryKey[0] === 'products' });
     },
   });
 };


### PR DESCRIPTION
## 🔧 작업 내용

1. 팔로잉 프리뷰에 API를 연동하였습니다.
- 팔로우 목록 프리뷰 리스트
- 팔로우/팔로우 취소 기능

2. 로그인 및 로그아웃 시 상품 리스트 캐시를 invalidate하도록 수정하였습니다
- 로그인 한 경우 스크랩 여부를 최신화 해야 하기 때문에 관련해서 수정 했습니다.

## 📸 스크린샷 (선택)

![image](https://github.com/user-attachments/assets/82476388-cc61-462a-afc4-ff6a36053a47)
