### PR TITLE
feat(shared): ProductCard 컴포넌트 스크랩 기능 추가

### DIFF
--- a/app/_components/product/ProductCard.tsx
+++ b/app/_components/product/ProductCard.tsx
@@ -7,9 +7,7 @@ import { ROUTE_PATHS } from '@/constants';
 import { useScrapToggle } from '@/hooks/useScrapToggle';
 import { Product } from '@/lib/apis/products.type';
 import { CardBookmarkFilledIcon, CardBookmarkIcon } from '@/lib/icons';
-import { useUserSummary } from '@/lib/queries/useUserQueries';
 import { cn } from '@/lib/utils';
-import { useAuthDialog } from '@/stores/useAuthDialog';
 import { formatNumberWithComma, formatOverThousand } from '@/utils/formatNumber';
 import { getSizeLabelByValue } from '@/utils/item';
 
@@ -116,20 +114,8 @@ function ScrapButton({ product, hasScrapCount }: ScrapButtonProps) {
     product.totalScraped
   );
 
-  const { toggleIsOpen: toggleAuthDialogOpen } = useAuthDialog();
-  const { data: user } = useUserSummary();
-
-  const handleScrapButtonClick = () => {
-    if (!user || !user.result) {
-      toggleAuthDialogOpen();
-      return;
-    }
-
-    toggleIsScraped();
-  };
-
   return (
-    <button onClick={handleScrapButtonClick} className="cursor-pointer">
+    <button onClick={toggleIsScraped} className="cursor-pointer">
       {isScraped ? <CardBookmarkFilledIcon /> : <CardBookmarkIcon />}
       {hasScrapCount && (
         <p className="text-custom-background text-xs">{formatOverThousand(scrapCount)}</p>

--- a/hooks/useFollowToggle.ts
+++ b/hooks/useFollowToggle.ts
@@ -3,6 +3,8 @@ import { useState } from 'react';
 import { useDebouncedCallback } from '@/hooks/useDebounce';
 import { useToggleFollow } from '@/lib/queries/useFollowingQueries';
 
+import { useRequireAuth } from './useRequireAuth';
+
 /**
  * 작가 팔로우 상태를 토글하는 커스텀 훅
  * @param artistId - 작가 ID
@@ -33,10 +35,18 @@ export function useFollowToggle(artistId: number, initialIsFollowing: boolean) {
     );
   }, 500);
 
-  const toggleIsFollowing = () => {
+  const toggleFollowState = () => {
     const nextIsFollowing = !isFollowing;
     setIsFollowing(nextIsFollowing);
     debouncedToggleFollow(nextIsFollowing);
+  };
+
+  const { checkAuth } = useRequireAuth();
+
+  const toggleIsFollowing = () => {
+    checkAuth(() => {
+      toggleFollowState();
+    });
   };
 
   return {

--- a/hooks/useRequireAuth.ts
+++ b/hooks/useRequireAuth.ts
@@ -1,0 +1,38 @@
+import { useUserSummary } from '@/lib/queries/useUserQueries';
+import { useAuthDialog } from '@/stores/useAuthDialog';
+
+/**
+ * 인증이 필요한 동작을 감싸는 헬퍼 훅
+ *
+ * 인증되지 않은 경우 인증 다이얼로그를 띄우고,
+ * 인증된 경우에만 주어진 콜백 함수를 실행합니다.
+ *
+ * @returns checkAuth - 인증 상태 확인 후 콜백 실행 함수
+ *
+ * @example
+ * const { checkAuth } = useRequireAuth();
+ *
+ * const handleClick = () => {
+ *   checkAuth(() => {
+ *     // 인증된 유저만 실행되는 로직
+ *     doSomethingProtected();
+ *   });
+ * };
+ */
+export function useRequireAuth() {
+  const { data: user } = useUserSummary();
+  const { toggleIsOpen: toggleAuthDialogOpen } = useAuthDialog();
+
+  // 유저가 인증된 경우에만 콜백 실행
+  const checkAuth = (onAuthed: () => void) => {
+    if (!user || !user.result) {
+      toggleAuthDialogOpen();
+      return;
+    }
+
+    // 인증된 경우 해당 콜백 실행
+    onAuthed();
+  };
+
+  return { checkAuth };
+}

--- a/hooks/useScrapToggle.ts
+++ b/hooks/useScrapToggle.ts
@@ -3,6 +3,8 @@ import { useState } from 'react';
 import { useDebouncedCallback } from '@/hooks/useDebounce';
 import { useToggleProductScrap } from '@/lib/queries/useProductsQueries';
 
+import { useRequireAuth } from './useRequireAuth';
+
 /**
  * 제품 스크랩 상태를 토글하는 커스텀 훅
  * @param productId - 제품 ID
@@ -43,7 +45,7 @@ export function useScrapToggle(
     500
   );
 
-  const toggleIsScraped = () => {
+  const toggleScrapState = () => {
     const nextIsScrapped = !isScraped;
     const prevScrapCount = scrapCount;
     const nextScrapCount = isScraped ? scrapCount - 1 : scrapCount + 1;
@@ -52,6 +54,15 @@ export function useScrapToggle(
     setScrapCount(nextScrapCount);
 
     debouncedToggleScrap(nextIsScrapped, prevScrapCount);
+  };
+
+  // 인증 상태 확인
+  const { checkAuth } = useRequireAuth();
+
+  const toggleIsScraped = () => {
+    checkAuth(() => {
+      toggleScrapState();
+    });
   };
 
   return {

--- a/hooks/useScrapToggle.ts
+++ b/hooks/useScrapToggle.ts
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+
+import { useDebouncedCallback } from '@/hooks/useDebounce';
+import { useToggleProductScrap } from '@/lib/queries/useProductsQueries';
+
+/**
+ * 제품 스크랩 상태를 토글하는 커스텀 훅
+ * @param productId - 제품 ID
+ * @param initialIsScraped - 초기 스크랩 여부
+ * @param initialScrapCount - 초기 스크랩 수
+ */
+export function useScrapToggle(
+  productId: number,
+  initialIsScraped: boolean,
+  initialScrapCount: number
+) {
+  const [isScraped, setIsScrapped] = useState(initialIsScraped); // UI 상태
+  const [scrapCount, setScrapCount] = useState(initialScrapCount); // UI 상태
+  const [serverScrapState, setServerScrapState] = useState(initialIsScraped); // 서버와 동기화 된 상태
+
+  const { mutate: toggleScrap } = useToggleProductScrap();
+
+  const debouncedToggleScrap = useDebouncedCallback(
+    (nextIsScrapped: boolean, previousScrapCount: number) => {
+      // 서버 상태와 요청한 상태가 동일한 경우 API 요청 하지 않음
+      if (nextIsScrapped === serverScrapState) return;
+
+      toggleScrap(
+        { productId, isScraped: serverScrapState },
+        {
+          onSuccess: () => {
+            // 성공 시 서버 상태를 요청한 상태로 변경
+            setServerScrapState(nextIsScrapped);
+          },
+          onError: () => {
+            // 요청 실패 시 서버 상태와 동일한 상태로 롤백
+            setIsScrapped(serverScrapState);
+            setScrapCount(previousScrapCount);
+          },
+        }
+      );
+    },
+    500
+  );
+
+  const toggleIsScraped = () => {
+    const nextIsScrapped = !isScraped;
+    const prevScrapCount = scrapCount;
+    const nextScrapCount = isScraped ? scrapCount - 1 : scrapCount + 1;
+
+    setIsScrapped(nextIsScrapped);
+    setScrapCount(nextScrapCount);
+
+    debouncedToggleScrap(nextIsScrapped, prevScrapCount);
+  };
+
+  return {
+    isScraped,
+    scrapCount,
+    toggleIsScraped,
+  };
+}

--- a/lib/apis/products.api.ts
+++ b/lib/apis/products.api.ts
@@ -2,7 +2,7 @@ import { API_BASE_URL } from '@/constants';
 import { createQueryParams } from '@/utils/queryParams';
 
 import { fetchWithAuth } from './common.api';
-import { ErrorResponse } from './common.type';
+import { ErrorResponse, SuccessResponse } from './common.type';
 import { ProductsListQueryParams, ProductsListResponse } from './products.type';
 
 export const fetchProductsList = async (
@@ -26,4 +26,32 @@ export const fetchProductsList = async (
   }
 
   return data as ProductsListResponse;
+};
+
+export const scrapProducts = async (productId: number) => {
+  const res = await fetchWithAuth(`${API_BASE_URL.CLIENT}/api/v1/scraps/${productId}`, {
+    method: 'POST',
+  });
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw data as ErrorResponse;
+  }
+
+  return data as SuccessResponse;
+};
+
+export const unScrapProducts = async (productId: number) => {
+  const res = await fetchWithAuth(`${API_BASE_URL.CLIENT}/api/v1/scraps/${productId}`, {
+    method: 'DELETE',
+  });
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw data as ErrorResponse;
+  }
+
+  return data as SuccessResponse;
 };

--- a/lib/apis/user.type.ts
+++ b/lib/apis/user.type.ts
@@ -3,7 +3,7 @@ import { SuccessResponse } from './common.type';
 export interface UserSummary {
   userId: number;
   profileImgUrl: string;
-  email: string;
+  nickname: string;
   role: 'USER' | 'ARTIST';
 }
 

--- a/lib/queries/useProductsQueries.ts
+++ b/lib/queries/useProductsQueries.ts
@@ -1,6 +1,6 @@
-import { useInfiniteQuery, useQuery, UseQueryOptions } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useQuery, UseQueryOptions } from '@tanstack/react-query';
 
-import { fetchProductsList } from '../apis/products.api';
+import { fetchProductsList, scrapProducts, unScrapProducts } from '../apis/products.api';
 import { ProductsListQueryParams, ProductsListResponse } from '../apis/products.type';
 
 import { QUERY_KEYS } from './queryKeys';
@@ -34,5 +34,13 @@ export const useProductsInfiniteQuery = (
     },
     initialPageParam: initialPage,
     enabled,
+  });
+};
+
+export const useToggleProductScrap = () => {
+  return useMutation({
+    mutationFn: async ({ productId, isScraped }: { productId: number; isScraped: boolean }) => {
+      return isScraped ? await unScrapProducts(productId) : await scrapProducts(productId);
+    },
   });
 };


### PR DESCRIPTION
## 🔧 작업 내용

1. ProductCard에 스크랩 API를 연동하였습니다.

2. 공통 커스텀 훅을 만들었습니다.
- `useRequireAuth` : `checkAuth`를 리턴합니다. 해당 함수는 비로그인 유저의 경우 로그인 모달을 띄워줍니다.
```ts
// 사용 예시
const { checkAuth } = useRequireAuth();

const handleClick = () => {
  checkAuth(() => {
    // 인증된 유저만 실행되는 로직
    doSomethingProtected();
  });
};
```
- `useScrapToggle` : 작품 스크랩 상태를 토글하는 커스텀 훅입니다.
```ts
// 사용 예시
import React from 'react';
import { useScrapToggle } from './useScrapToggle';

export default function ProductScrapButton() {
  const productId = 1;
  const initialIsScraped = false;
  const initialScrapCount = 10;

  const { isScraped, scrapCount, toggleIsScraped } = useScrapToggle(
    productId,
    initialIsScraped,
    initialScrapCount
  );

  return (
    <button onClick={toggleIsScraped}>
      {isScraped ? '스크랩 취소' : '스크랩'} ({scrapCount})
    </button>
  );
}
```
