### PR TITLE
refactor(hooks): useFollowToggle 커스텀 훅 팔로잉 싱크 관련 리팩토링

### DIFF
--- a/app/(routes)/artists/[id]/_components/ArtistInfoButtons.tsx
+++ b/app/(routes)/artists/[id]/_components/ArtistInfoButtons.tsx
@@ -42,7 +42,9 @@ interface UserButtonGroupsProps {
 }
 
 export function UserButtonGroups({ artist }: UserButtonGroupsProps) {
-  const { isFollowing, toggleIsFollowing } = useFollowToggle(artist.id, artist.isFollowing);
+  const { isFollowing, toggleIsFollowing } = useFollowToggle(artist.id, artist.isFollowing, {
+    invalidateFollowingQueries: true,
+  });
 
   return (
     <div className="mt-10 flex w-full flex-col gap-2.5">

--- a/app/(routes)/mypage/following/_components/FollowingArtistRow.tsx
+++ b/app/(routes)/mypage/following/_components/FollowingArtistRow.tsx
@@ -1,16 +1,12 @@
-import { useState } from 'react';
-
 import Link from 'next/link';
 
 import ProductCard from '@/app/_components/product/ProductCard';
 import ProfileImage from '@/app/_components/shared/ProfileImage';
 import { ROUTE_PATHS } from '@/constants';
-import { useDebouncedCallback } from '@/hooks/useDebounce';
 import { useFollowToggle } from '@/hooks/useFollowToggle';
 import { FollowingArtist } from '@/lib/apis/following.type';
 import { Product } from '@/lib/apis/products.type';
 import { AddIcon, CheckIcon } from '@/lib/icons';
-import { useToggleFollow } from '@/lib/queries/useFollowingQueries';
 import { cn } from '@/lib/utils';
 import { formatOverThousand } from '@/utils/formatNumber';
 
@@ -32,7 +28,9 @@ interface FollowingArtistInfoProps {
 }
 
 function FollowingArtistInfo({ artist }: FollowingArtistInfoProps) {
-  const { isFollowing, toggleIsFollowing } = useFollowToggle(artist.id, artist.isFollowing);
+  const { isFollowing, toggleIsFollowing } = useFollowToggle(artist.id, artist.isFollowing, {
+    invalidateFollowingPreview: true,
+  });
 
   return (
     <div className="flex flex-col items-center justify-between">

--- a/app/actions/revalidate.ts
+++ b/app/actions/revalidate.ts
@@ -1,0 +1,9 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { ROUTE_PATHS } from '@/constants';
+
+export async function revalidateArtistPath(artistId: number) {
+  revalidatePath(ROUTE_PATHS.ARTIST(String(artistId)));
+}

--- a/app/actions/revalidate.ts
+++ b/app/actions/revalidate.ts
@@ -1,9 +1,7 @@
 'use server';
 
-import { revalidatePath } from 'next/cache';
+import { revalidateTag } from 'next/cache';
 
-import { ROUTE_PATHS } from '@/constants';
-
-export async function revalidateArtistPath(artistId: number) {
-  revalidatePath(ROUTE_PATHS.ARTIST(String(artistId)));
+export async function revalidateArtistTag(artistId: string) {
+  revalidateTag(`artist-${artistId}`);
 }

--- a/hooks/useFollowToggle.ts
+++ b/hooks/useFollowToggle.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 
+import { revalidateArtistPath } from '@/app/actions/revalidate';
 import { useDebouncedCallback } from '@/hooks/useDebounce';
 import { useToggleFollow } from '@/lib/queries/useFollowingQueries';
 
@@ -36,6 +37,9 @@ export function useFollowToggle(
         onSuccess: async () => {
           // 성공 시 서버 상태를 요청한 상태로 변경
           setServerFollowState(nextIsFollowing);
+
+          // 팔로우 변경시 작가 피드 페이지 갱신, 바로 반영되지는 않고 페이지 재요청시 갱신됨
+          await revalidateArtistPath(artistId);
 
           // TanStack Query를 사용하는 모든 query invalidate
           // e.g. 작가 피드 페이지 팔로우 기능 변경 시 layout과 팔로우 목록 페이지 invalidate

--- a/hooks/useFollowToggle.ts
+++ b/hooks/useFollowToggle.ts
@@ -96,13 +96,19 @@ export function useFollowToggle(
             queryClient.invalidateQueries({ queryKey: QUERY_KEYS.following.preview });
           }
         },
-        onError: () => {
-          // 요청 실패 시 서버 상태와 동일한 상태로 롤백
-          setIsFollowing(serverFollowState);
+        onError: async () => {
+          // 요청 실패 시 UI 상태 롤백
+          setServerFollowState(serverFollowState);
+
+          // 요청 실패 시 서버 상태와 동기화 진행
+          await revalidateArtistTag(String(artistId));
+          queryClient.invalidateQueries({
+            predicate: (query) => query.queryKey[0] === 'following',
+          });
         },
       }
     );
-  }, 500);
+  }, 200);
 
   const toggleFollowState = () => {
     const nextIsFollowing = !isFollowing;

--- a/hooks/useFollowToggle.ts
+++ b/hooks/useFollowToggle.ts
@@ -18,6 +18,7 @@ export function useFollowToggle(
   initialIsFollowing: boolean,
   options?: {
     invalidateFollowingQueries?: boolean;
+    invalidateFollowingPreview?: boolean;
   }
 ) {
   const [isFollowing, setIsFollowing] = useState(initialIsFollowing); // UI 상태
@@ -47,6 +48,11 @@ export function useFollowToggle(
             queryClient.invalidateQueries({
               predicate: (query) => query.queryKey[0] === 'following',
             });
+          }
+
+          // 팔로우 페이지의 첫 번째 목록에서 변화가 생기는 경우 preview invalidate
+          if (options?.invalidateFollowingPreview) {
+            queryClient.invalidateQueries({ queryKey: QUERY_KEYS.following.preview });
           }
         },
         onError: () => {

--- a/hooks/useFollowToggle.ts
+++ b/hooks/useFollowToggle.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 
-import { revalidateArtistPath } from '@/app/actions/revalidate';
+import { revalidateArtistTag } from '@/app/actions/revalidate';
 import { useDebouncedCallback } from '@/hooks/useDebounce';
 import { useToggleFollow } from '@/lib/queries/useFollowingQueries';
 
@@ -39,7 +39,7 @@ export function useFollowToggle(
           setServerFollowState(nextIsFollowing);
 
           // 팔로우 변경시 작가 피드 페이지 갱신, 바로 반영되지는 않고 페이지 재요청시 갱신됨
-          await revalidateArtistPath(artistId);
+          await revalidateArtistTag(String(artistId));
 
           // TanStack Query를 사용하는 모든 query invalidate
           // e.g. 작가 피드 페이지 팔로우 기능 변경 시 layout과 팔로우 목록 페이지 invalidate

--- a/lib/apis/user.api.ts
+++ b/lib/apis/user.api.ts
@@ -61,7 +61,9 @@ export const fetchArtistDetail = async (
 
   const baseUrl = mergedOptions.runtime === 'server' ? API_BASE_URL.SERVER : API_BASE_URL.CLIENT;
 
-  const res = await fetchWithAuth(`${baseUrl}/api/v1/users/artists/${artistId}`);
+  const res = await fetchWithAuth(`${baseUrl}/api/v1/users/artists/${artistId}`, {
+    next: { tags: [`artist-${artistId}`] },
+  });
 
   const data = await res.json();
 


### PR DESCRIPTION
## 🔧 작업 내용

1. useFollowToggle이 사용되는 데이터들의 싱크에 대한 수정사항이 반영되었습니다.
- 작가 피드 페이지 수정 시 : layout과 팔로잉 페이지 query invalidate
- 팔로우 프리뷰 (헤더) 수정 시 : 작가 피드 페이지와 팔로우 목록의 팔로우 상태와 일치
- 팔로우 목록 페이지 수정 시 : layout과 작가 피드 페이지 invalidate

⭐ 자세한 사항은 useFollowToggle의 JSDoc을 확인해주세요!
