### PR TITLE
refactor(hooks): useScrapToggle 커스텀 훅 리팩토링

### DIFF
--- a/app/_components/product/ScrapButton.tsx
+++ b/app/_components/product/ScrapButton.tsx
@@ -11,17 +11,13 @@ interface ScrapButtonProps {
 }
 
 export default function ScrapButton({ product, hasScrapCount }: ScrapButtonProps) {
-  const { isScraped, scrapCount, toggleIsScraped } = useScrapToggle(
-    product.id,
-    product.scrap.isScrapped,
-    product.totalScraped
-  );
+  const { isScraped, toggleIsScraped } = useScrapToggle(product.id, product.scrap.isScrapped);
 
   return (
     <button onClick={toggleIsScraped} className="cursor-pointer">
       {isScraped ? <CardBookmarkFilledIcon /> : <CardBookmarkIcon />}
       {hasScrapCount && (
-        <p className="text-custom-background text-xs">{formatOverThousand(scrapCount)}</p>
+        <p className="text-custom-background text-xs">{formatOverThousand(product.totalScraped)}</p>
       )}
     </button>
   );

--- a/hooks/useScrapToggle.ts
+++ b/hooks/useScrapToggle.ts
@@ -9,51 +9,38 @@ import { useRequireAuth } from './useRequireAuth';
  * 제품 스크랩 상태를 토글하는 커스텀 훅
  * @param productId - 제품 ID
  * @param initialIsScraped - 초기 스크랩 여부
- * @param initialScrapCount - 초기 스크랩 수
  */
-export function useScrapToggle(
-  productId: number,
-  initialIsScraped: boolean,
-  initialScrapCount: number
-) {
+export function useScrapToggle(productId: number, initialIsScraped: boolean) {
   const [isScraped, setIsScrapped] = useState(initialIsScraped); // UI 상태
-  const [scrapCount, setScrapCount] = useState(initialScrapCount); // UI 상태
   const [serverScrapState, setServerScrapState] = useState(initialIsScraped); // 서버와 동기화 된 상태
 
   const { mutate: toggleScrap } = useToggleProductScrap();
 
-  const debouncedToggleScrap = useDebouncedCallback(
-    (nextIsScrapped: boolean, previousScrapCount: number) => {
-      // 서버 상태와 요청한 상태가 동일한 경우 API 요청 하지 않음
-      if (nextIsScrapped === serverScrapState) return;
+  const debouncedToggleScrap = useDebouncedCallback((nextIsScrapped: boolean) => {
+    // 서버 상태와 요청한 상태가 동일한 경우 API 요청 하지 않음
+    if (nextIsScrapped === serverScrapState) return;
 
-      toggleScrap(
-        { productId, isScraped: serverScrapState },
-        {
-          onSuccess: () => {
-            // 성공 시 서버 상태를 요청한 상태로 변경
-            setServerScrapState(nextIsScrapped);
-          },
-          onError: () => {
-            // 요청 실패 시 서버 상태와 동일한 상태로 롤백
-            setIsScrapped(serverScrapState);
-            setScrapCount(previousScrapCount);
-          },
-        }
-      );
-    },
-    500
-  );
+    toggleScrap(
+      { productId, isScraped: serverScrapState },
+      {
+        onSuccess: () => {
+          // 성공 시 서버 상태를 요청한 상태로 변경
+          setServerScrapState(nextIsScrapped);
+        },
+        onError: () => {
+          // 요청 실패 시 서버 상태와 동일한 상태로 롤백
+          setIsScrapped(serverScrapState);
+        },
+      }
+    );
+  }, 500);
 
   const toggleScrapState = () => {
     const nextIsScrapped = !isScraped;
-    const prevScrapCount = scrapCount;
-    const nextScrapCount = isScraped ? scrapCount - 1 : scrapCount + 1;
 
     setIsScrapped(nextIsScrapped);
-    setScrapCount(nextScrapCount);
 
-    debouncedToggleScrap(nextIsScrapped, prevScrapCount);
+    debouncedToggleScrap(nextIsScrapped);
   };
 
   // 인증 상태 확인
@@ -67,7 +54,6 @@ export function useScrapToggle(
 
   return {
     isScraped,
-    scrapCount,
     toggleIsScraped,
   };
 }

--- a/hooks/useScrapToggle.ts
+++ b/hooks/useScrapToggle.ts
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { useQueryClient } from '@tanstack/react-query';
+
 import { useDebouncedCallback } from '@/hooks/useDebounce';
 import { useToggleProductScrap } from '@/lib/queries/useProductsQueries';
 
@@ -14,6 +16,8 @@ export function useScrapToggle(productId: number, initialIsScraped: boolean) {
   const [isScraped, setIsScrapped] = useState(initialIsScraped); // UI 상태
   const [serverScrapState, setServerScrapState] = useState(initialIsScraped); // 서버와 동기화 된 상태
 
+  const queryClient = useQueryClient();
+
   const { mutate: toggleScrap } = useToggleProductScrap();
 
   const debouncedToggleScrap = useDebouncedCallback((nextIsScrapped: boolean) => {
@@ -26,6 +30,9 @@ export function useScrapToggle(productId: number, initialIsScraped: boolean) {
         onSuccess: () => {
           // 성공 시 서버 상태를 요청한 상태로 변경
           setServerScrapState(nextIsScrapped);
+
+          // 스크랩 관련 query invalidate
+          queryClient.invalidateQueries({ predicate: (query) => query.queryKey[0] === 'products' });
         },
         onError: () => {
           // 요청 실패 시 서버 상태와 동일한 상태로 롤백


### PR DESCRIPTION
## 🔧 작업 내용

1. Scrap count 값에 대한 낙관적 업데이트 기능을 제거했습니다.
- 서버에서 해당 count 값을 10분에서 2시간 마다 update 하기 때문에 버그를 방지하기 위해 낙관적 업데이트 X

2. Scrap을 한 경우 관련된 query를 invalidate 하여 scrap 정보를 다시 불러오도록 하였습니다.
- 추후 product detail에 관련된 query key가 생성되면 해당 값을 반영하여 수정이 필요할 수 있습니다! (디테일은 invalidate X)
