### PR TITLE
feat(ui): shadcn/ui sonner 추가 및 일부 적용

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from 'next/font/local';
 import Script from 'next/script';
 
 import Providers from '@/app/_provider';
+import { Toaster } from '@/components/ui/sonner';
 
 import GlobalNavBar from './_components/layout/GlobalNavBar';
 import LoginDialog from './_components/shared/LoginDialog';
@@ -100,6 +101,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <div className="pt-14" />
           {children}
           <LoginDialog />
+          <Toaster position="bottom-center" />
         </Providers>
       </body>
     </html>

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useTheme } from 'next-themes';
+
+import { Toaster as Sonner, ToasterProps } from 'sonner';
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = 'system' } = useTheme();
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps['theme']}
+      className="toaster group"
+      style={
+        {
+          '--normal-bg': 'var(--popover)',
+          '--normal-text': 'var(--popover-foreground)',
+          '--normal-border': 'var(--border)',
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  );
+};
+
+export { Toaster };

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -10,7 +10,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
   return (
     <Sonner
       theme={theme as ToasterProps['theme']}
-      className="toaster group"
+      className="toaster group !w-full"
       style={
         {
           '--normal-bg': 'var(--popover)',

--- a/hooks/useFollowToggle.ts
+++ b/hooks/useFollowToggle.ts
@@ -7,6 +7,7 @@ import { useDebouncedCallback } from '@/hooks/useDebounce';
 import { FollowingArtistsResponse, FollowingPreviewResponse } from '@/lib/apis/following.type';
 import { QUERY_KEYS } from '@/lib/queries/queryKeys';
 import { useToggleFollow } from '@/lib/queries/useFollowingQueries';
+import toast from '@/lib/toast';
 
 import { useRequireAuth } from './useRequireAuth';
 
@@ -109,6 +110,10 @@ export function useFollowToggle(
           if (options?.invalidateFollowingPreview) {
             queryClient.invalidateQueries({ queryKey: QUERY_KEYS.following.preview });
           }
+
+          toast.default(
+            nextIsFollowing ? '작가 팔로우를 시작했습니다' : '작가 팔로우를 취소했습니다'
+          );
         },
         onError: async () => {
           // 요청 실패 시 UI 상태 롤백
@@ -119,6 +124,8 @@ export function useFollowToggle(
           queryClient.invalidateQueries({
             predicate: (query) => query.queryKey[0] === 'following',
           });
+
+          toast.error('잠시 후 다시 시도해주세요');
         },
       }
     );

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -1,0 +1,24 @@
+import { toast as sonner } from 'sonner';
+
+const toast = {
+  default: (title: string, options: { duration: number } = { duration: 3000 }) =>
+    sonner(title, {
+      duration: options.duration,
+      classNames: {
+        toast:
+          'left-1/2 -translate-x-1/2 !w-auto !py-2 !rounded-full !border-custom-background !bg-custom-brand-primary',
+        title: 'text-xs !text-custom-background',
+      },
+    }),
+  error: (title: string, options: { duration: number } = { duration: 3000 }) =>
+    sonner(title, {
+      duration: options.duration,
+      classNames: {
+        toast:
+          'left-1/2 -translate-x-1/2 !w-auto !py-2 !rounded-full !border-custom-status-negative !bg-[#F7E6E6]',
+        title: 'text-xs !text-custom-status-negative',
+      },
+    }),
+};
+
+export default toast;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.56.1",
+    "sonner": "^2.0.3",
     "swiper": "^11.2.6",
     "tailwind-merge": "^3.2.0",
     "tw-animate-css": "^1.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
       react-hook-form:
         specifier: ^7.56.1
         version: 7.56.1(react@19.1.0)
+      sonner:
+        specifier: ^2.0.3
+        version: 2.0.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       swiper:
         specifier: ^11.2.6
         version: 11.2.6
@@ -3723,6 +3726,12 @@ packages:
 
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
+
+  sonner@2.0.3:
+    resolution: {integrity: sha512-njQ4Hht92m0sMqqHVDL32V2Oun9W1+PHO9NDv9FHfJjT3JT22IG4Jpo3FPQy+mouRKCXFWO+r67v6MrHX2zeIA==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -7912,6 +7921,11 @@ snapshots:
     dependencies:
       dot-case: 3.0.4
       tslib: 2.8.1
+
+  sonner@2.0.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   source-map-js@1.2.1: {}
 


### PR DESCRIPTION
## 🔧 작업 내용

1. shadcn/ui의 sonner를 추가하였습니다.
- lib의 toast를 활용하여 코드를 작성해주시면 됩니다!
- 사용 예시 https://github.com/swyp-9-web/indi-front/commit/a77882c17ae3909a6c2f79de7349d26333009832
