### PR TITLE
feat(middleware): 미들웨어 라우트 가드 설정 추가

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+import { ROUTE_PATHS } from './constants';
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const token = request.cookies.get('JSESSIONID')?.value;
+
+  // 정확히 일치해야 하는 보호 경로
+  const PROTECTED_PATHS = [ROUTE_PATHS.REGISTER_PRODUCT, ROUTE_PATHS.MYPAGE];
+
+  // 하위 경로까지 포함해서 보호해야 하는 prefix 경로
+  const PROTECTED_PREFIXES = [ROUTE_PATHS.MYPAGE];
+
+  const isProtected =
+    PROTECTED_PATHS.includes(pathname) ||
+    PROTECTED_PREFIXES.some((prefix) => pathname.startsWith(`${prefix}/`));
+
+  if (isProtected && !token) {
+    return NextResponse.redirect(new URL(ROUTE_PATHS.HOME, request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/:path*'],
+};


### PR DESCRIPTION
## 🔧 작업 내용

1. Next middleware.ts 를 통한 라우트 가드 설정을 추가하였습니다.
- `/mypage`로 시작하는 경로 및 `/artists/products/register` (작품 등록) 경로에서 로그인하지 않은 경우 홈으로 이동합니다.
