### PR TITLE
feat(register): 작품 정보 수정 기능 일부 구현 및 product register 페이지 리팩토링

### DIFF
--- a/app/(routes)/artists/[id]/_components/ArtistInfoSection/ArtistInfoButtonGroups.tsx
+++ b/app/(routes)/artists/[id]/_components/ArtistInfoSection/ArtistInfoButtonGroups.tsx
@@ -1,9 +1,7 @@
 'use client';
 
-import Link from 'next/link';
-
-import { ROUTE_PATHS } from '@/constants';
 import { useFollowToggle } from '@/hooks/useFollowToggle';
+import { useProductRegisterPage } from '@/hooks/useProductRegisterPage';
 import { ArtistDetail } from '@/lib/apis/user.type';
 import { AddIcon, CheckIcon, ShareIcon } from '@/lib/icons';
 import toast from '@/lib/toast';
@@ -27,6 +25,7 @@ export function ShareLinkButton() {
 }
 
 export function ArtistButtonGroups() {
+  const enterRegisterPage = useProductRegisterPage();
   return (
     <div className="mt-10 flex w-full flex-col gap-2.5">
       <button className="border-custom-gray-100 flex h-12 w-full cursor-pointer items-center justify-center rounded-full border text-sm font-medium">
@@ -37,12 +36,12 @@ export function ArtistButtonGroups() {
         임시저장된 글
       </button>
 
-      <Link
-        href={ROUTE_PATHS.REGISTER_PRODUCT}
+      <button
+        onClick={enterRegisterPage.create}
         className="bg-custom-brand-secondary text-custom-gray-900 flex h-12 w-full items-center justify-center rounded-full text-sm font-medium"
       >
         작품 등록
-      </Link>
+      </button>
     </div>
   );
 }

--- a/app/(routes)/artists/products/register/_components/ProductRegisterForm.tsx
+++ b/app/(routes)/artists/products/register/_components/ProductRegisterForm.tsx
@@ -17,7 +17,7 @@ import ProductInfoInputs from './ProductInfoInputs';
 
 export default function ProductRegisterForm() {
   const router = useRouter();
-  const { mode, initialValues, initialImgUrls } = useProductRegisterForm();
+  const { mode, initialValues, initialImgUrls, resetFormState } = useProductRegisterForm();
 
   const [productImages, setProductImages] = useState<(string | File)[]>(initialImgUrls);
   const [imageOrder, setImageOrder] = useState<string[]>(initialImgUrls);
@@ -51,7 +51,7 @@ export default function ProductRegisterForm() {
   const { mutate: registerProduct } = useRegisterProduct();
 
   const handleSubmit = async (formValues: FormValues) => {
-    if (mode !== 'CREATE') return;
+    if (mode !== 'CREATE' || submitType === 'TEMP') return;
 
     const formData = new FormData();
 
@@ -87,6 +87,8 @@ export default function ProductRegisterForm() {
       onSuccess: (data) => {
         const productId = data.result.itemId;
         router.replace(ROUTE_PATHS.PRODUCT_DETAIL(String(productId)));
+
+        resetFormState();
 
         toast.default('상품을 등록하였습니다');
       },

--- a/app/(routes)/artists/products/register/_components/ProductRegisterForm.tsx
+++ b/app/(routes)/artists/products/register/_components/ProductRegisterForm.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
@@ -12,23 +10,17 @@ import { ROUTE_PATHS } from '@/constants';
 import { useRegisterProduct } from '@/lib/queries/useProductsQueries';
 import { FormValues, productRegisterFormSchema } from '@/lib/schemas/productRegisterForm.schema';
 import toast from '@/lib/toast';
+import { useProductRegisterForm } from '@/stores/useProductRegisterForm';
 
 import ImageUploadInput from './ImageUploadInput';
 import ProductInfoInputs from './ProductInfoInputs';
 
-interface ProductRegisterFormProps {
-  initialValues: Partial<FormValues> | null;
-  initialImgUrls?: string[];
-}
-
-export default function ProductRegisterForm({
-  initialValues,
-  initialImgUrls,
-}: ProductRegisterFormProps) {
+export default function ProductRegisterForm() {
   const router = useRouter();
+  const { mode, initialValues, initialImgUrls } = useProductRegisterForm();
 
-  const [productImages, setProductImages] = useState<(string | File)[]>(initialImgUrls ?? []);
-  const [imageOrder, setImageOrder] = useState<string[]>(initialImgUrls ?? []);
+  const [productImages, setProductImages] = useState<(string | File)[]>(initialImgUrls);
+  const [imageOrder, setImageOrder] = useState<string[]>(initialImgUrls);
 
   const [submitType, setSubmitType] = useState<'TEMP' | 'OPEN'>('OPEN');
 
@@ -59,6 +51,8 @@ export default function ProductRegisterForm({
   const { mutate: registerProduct } = useRegisterProduct();
 
   const handleSubmit = async (formValues: FormValues) => {
+    if (mode !== 'CREATE') return;
+
     const formData = new FormData();
 
     const { priceType: _priceType, ...formValuesWithoutPriceType } = formValues;

--- a/app/(routes)/artists/products/register/page.tsx
+++ b/app/(routes)/artists/products/register/page.tsx
@@ -1,12 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { ROUTE_PATHS } from '@/constants';
+import toast from '@/lib/toast';
+import { useProductRegisterForm } from '@/stores/useProductRegisterForm';
+
 import ProductRegisterForm from './_components/ProductRegisterForm';
 
-// TODO: 동작(수정, 임시저장)에 따라 initialValue를 zustand 혹은 query로 받아서 설정해줘야 함
 export default function RegisterProduct() {
+  const router = useRouter();
+  const { mode, resetFormState } = useProductRegisterForm();
+
+  // useProductRegisterPage 훅을 활용해 접근하지 않은 경우 redirect
+  useEffect(() => {
+    if (!mode) {
+      // 유저 전용 에러 메시지, 뒤로가기로 진입, URL 접근 등 방지
+      router.replace(ROUTE_PATHS.HOME);
+
+      console.error('잘못된 접근입니다. useProductRegisterPage를 통해 접근해주세요.');
+      toast.error('잘못된 접근입니다');
+    }
+
+    return () => resetFormState();
+  }, [mode, router, resetFormState]);
+
+  if (!mode) return null;
+
   return (
     <main className="w-8xl mx-auto mt-25 px-20">
       <h2 className="text-custom-brand-primary mb-12.5 text-2xl font-bold">작품 등록하기</h2>
 
-      <ProductRegisterForm initialValues={null} />
+      <ProductRegisterForm />
     </main>
   );
 }

--- a/app/(routes)/artists/products/register/page.tsx
+++ b/app/(routes)/artists/products/register/page.tsx
@@ -23,7 +23,7 @@ export default function RegisterProduct() {
       console.error('잘못된 접근입니다. useProductRegisterPage를 통해 접근해주세요.');
       toast.error('잘못된 접근입니다');
     }
-  }, [mode, router]);
+  }, [router]);
 
   if (!mode) return null;
 

--- a/app/(routes)/artists/products/register/page.tsx
+++ b/app/(routes)/artists/products/register/page.tsx
@@ -12,7 +12,7 @@ import ProductRegisterForm from './_components/ProductRegisterForm';
 
 export default function RegisterProduct() {
   const router = useRouter();
-  const { mode, resetFormState } = useProductRegisterForm();
+  const { mode } = useProductRegisterForm();
 
   // useProductRegisterPage 훅을 활용해 접근하지 않은 경우 redirect
   useEffect(() => {
@@ -23,9 +23,7 @@ export default function RegisterProduct() {
       console.error('잘못된 접근입니다. useProductRegisterPage를 통해 접근해주세요.');
       toast.error('잘못된 접근입니다');
     }
-
-    return () => resetFormState();
-  }, [mode, router, resetFormState]);
+  }, [mode, router]);
 
   if (!mode) return null;
 

--- a/app/_components/layout/HeaderRightSection/index.tsx
+++ b/app/_components/layout/HeaderRightSection/index.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 
 import { ROUTE_PATHS } from '@/constants';
+import { useProductRegisterPage } from '@/hooks/useProductRegisterPage';
 import { BookmarkIcon } from '@/lib/icons';
 import { useUserSummary } from '@/lib/queries/useUserQueries';
 import { useAuthDialog } from '@/stores/useAuthDialog';
@@ -12,6 +13,7 @@ import UserProfileDropdown from './UserProfileDropdown';
 
 export default function HeaderRightSection() {
   const { toggleIsOpen } = useAuthDialog();
+  const enterRegisterPage = useProductRegisterPage();
 
   const { data } = useUserSummary();
 
@@ -20,12 +22,12 @@ export default function HeaderRightSection() {
   return (
     <div className="flex flex-1 justify-end">
       {user && user.role === 'ARTIST' && (
-        <Link
-          href={ROUTE_PATHS.REGISTER_PRODUCT}
-          className="text-custom-gray-900 bg-custom-brand-secondary mr-5 flex h-9.5 w-37.5 items-center justify-center rounded-full text-sm font-medium"
+        <button
+          onClick={enterRegisterPage.create}
+          className="text-custom-gray-900 bg-custom-brand-secondary mr-5 flex h-9.5 w-37.5 cursor-pointer items-center justify-center rounded-full text-sm font-medium"
         >
           작품 등록하기
-        </Link>
+        </button>
       )}
 
       {user && (

--- a/hooks/useProductRegisterPage.ts
+++ b/hooks/useProductRegisterPage.ts
@@ -1,0 +1,41 @@
+import { useRouter } from 'next/navigation';
+
+import { ROUTE_PATHS } from '@/constants';
+import { useProductRegisterForm } from '@/stores/useProductRegisterForm';
+
+/**
+ * 상품 등록 페이지를 관리하는 커스텀 훅입니다.
+ *
+ * 반드시 해당 훅을 통헤서 상품 등록 페이지 (`ROUTE_PATHS.REGISTER_PRODUCT`에 진입할 수 있습니다.)
+ */
+export function useProductRegisterPage() {
+  const router = useRouter();
+  const { setMode, setInitialFormValues } = useProductRegisterForm();
+
+  const enterRegisterPage = {
+    create: () => {
+      setMode('CREATE');
+      setInitialFormValues({ initialValues: null, initialImgUrls: [] });
+      router.push(ROUTE_PATHS.REGISTER_PRODUCT);
+    },
+
+    edit: ({ productId }: { productId: number }) => {
+      setMode('EDIT');
+
+      // TODO: productId를 통해 세부 정보를 불러와서 initialValue를 설정
+      console.log(productId);
+
+      router.push(ROUTE_PATHS.REGISTER_PRODUCT);
+    },
+
+    tempEdit: () => {
+      setMode('TEMP_EDIT');
+
+      // 현재 유저 정보를 통해 임시 저장된 값을 불러와서 initialValue를 설정하는 로직 추가 필요
+
+      router.push(ROUTE_PATHS.REGISTER_PRODUCT);
+    },
+  };
+
+  return enterRegisterPage;
+}

--- a/hooks/useProductRegisterPage.ts
+++ b/hooks/useProductRegisterPage.ts
@@ -17,7 +17,7 @@ import { useProductRegisterForm } from '@/stores/useProductRegisterForm';
  */
 export function useProductRegisterPage() {
   const router = useRouter();
-  const { setMode, setInitialFormValues } = useProductRegisterForm();
+  const { setMode, setInitialFormValues, setProductId } = useProductRegisterForm();
 
   const enterRegisterPage = {
     create: () => {
@@ -28,6 +28,7 @@ export function useProductRegisterPage() {
 
     edit: ({ productId }: { productId: number }) => {
       setMode('EDIT');
+      setProductId(productId);
 
       // TODO: productId를 통해 세부 정보를 불러와서 initialValue를 설정
       console.log(productId);

--- a/hooks/useProductRegisterPage.ts
+++ b/hooks/useProductRegisterPage.ts
@@ -4,9 +4,16 @@ import { ROUTE_PATHS } from '@/constants';
 import { useProductRegisterForm } from '@/stores/useProductRegisterForm';
 
 /**
- * 상품 등록 페이지를 관리하는 커스텀 훅입니다.
+ * 상품 등록/수정 및 임시저장 페이지 진입을 위한 커스텀 훅입니다.
  *
- * 반드시 해당 훅을 통헤서 상품 등록 페이지 (`ROUTE_PATHS.REGISTER_PRODUCT`에 진입할 수 있습니다.)
+ * 반드시 해당 훅을 통헤서 상품 등록 페이지 (`ROUTE_PATHS.REGISTER_PRODUCT`)로 이동해야 하며,
+ * 페이지 진입 시 mode 설정 및 초기 폼 데이터 초기화 로직을 포함합니다.
+ *
+ * 또한, 반드시 상품이 등록/수정/임시저장이 된 이후에는 `useProductRegisterForm`의 reset을 실행해 오류를 방지해야합니다.
+ *
+ * @example
+ *  const enterRegisterPage = useProductRegisterPage();
+ *  enterRegisterPage.create(); // 신규 등록 모드로 진입
  */
 export function useProductRegisterPage() {
   const router = useRouter();

--- a/lib/apis/products.api.ts
+++ b/lib/apis/products.api.ts
@@ -74,3 +74,18 @@ export const registerProduct = async (formData: FormData) => {
 
   return data as ProductRegisterResponse;
 };
+
+export const editProduct = async (formData: FormData, productId: number) => {
+  const res = await fetchWithAuth(`${API_BASE_URL.CLIENT}/api/v1/items/${productId}`, {
+    method: 'PATCH',
+    body: formData,
+  });
+
+  const data = await res.json();
+
+  if (!res.ok) {
+    throw data as ErrorResponse;
+  }
+
+  return data as ProductRegisterResponse;
+};

--- a/lib/queries/useProductsQueries.ts
+++ b/lib/queries/useProductsQueries.ts
@@ -7,6 +7,7 @@ import {
 } from '@tanstack/react-query';
 
 import {
+  editProduct,
   fetchProductsList,
   registerProduct,
   scrapProducts,
@@ -59,14 +60,32 @@ export const useToggleProductScrap = () => {
 /**
  * 작품 등록을 위한 mutation 훅입니다.
  *
- * 서버에 formData를 body로 보내프로필을 수정합니다.
- * 상품 등록에 성공한 경우 상품 정보를 invalidate 합니다.
+ * 서버에 formData를 body로 보내 작품을 등록합니다.
+ * 작품 등록에 성공한 경우 작품 정보를 invalidate 합니다.
  */
 export const useRegisterProduct = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: registerProduct,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ predicate: (query) => query.queryKey[0] === 'products' });
+    },
+  });
+};
+
+/**
+ * 작품 수정을 위한 mutation 훅입니다.
+ *
+ * 서버에 formData를 body로 보내 작품을 수정합니다.
+ * 작품 등록에 성공한 경우 작품 정보를 invalidate 합니다.
+ */
+export const useEditProduct = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ formData, productId }: { formData: FormData; productId: number }) =>
+      editProduct(formData, productId),
     onSuccess: () => {
       queryClient.invalidateQueries({ predicate: (query) => query.queryKey[0] === 'products' });
     },

--- a/stores/useProductRegisterForm.ts
+++ b/stores/useProductRegisterForm.ts
@@ -42,6 +42,7 @@ export const useProductRegisterForm = create<ProductRegisterFormStore>((set) => 
   resetFormState: () =>
     set({
       mode: null,
+      productId: null,
       initialValues: null,
       initialImgUrls: [],
     }),

--- a/stores/useProductRegisterForm.ts
+++ b/stores/useProductRegisterForm.ts
@@ -1,0 +1,48 @@
+import { create } from 'zustand';
+
+import { FormValues } from '@/lib/schemas/productRegisterForm.schema';
+
+export type Mode = 'CREATE' | 'EDIT' | 'TEMP_EDIT' | null;
+
+interface ProductRegisterFormState {
+  mode: Mode;
+  productId: number | null;
+  initialValues: Partial<FormValues> | null;
+  initialImgUrls: string[];
+}
+
+interface ProductRegisterFormActions {
+  setMode: (mode: Mode) => void;
+  setProductId: (productId: number) => void;
+  setInitialFormValues: (payload: {
+    initialValues: Partial<FormValues> | null;
+    initialImgUrls: string[];
+  }) => void;
+  resetFormState: () => void;
+}
+
+type ProductRegisterFormStore = ProductRegisterFormState & ProductRegisterFormActions;
+
+export const useProductRegisterForm = create<ProductRegisterFormStore>((set) => ({
+  mode: null,
+  productId: null,
+  initialValues: null,
+  initialImgUrls: [],
+
+  setMode: (mode) => set({ mode }),
+
+  // EDIT 모드인 경우 상품 아이디 설정
+  setProductId: (productId) => set({ productId }),
+
+  // 각각의 모드에 알맞는 초기값 설정
+  setInitialFormValues: ({ initialValues, initialImgUrls }) =>
+    set({ initialValues, initialImgUrls }),
+
+  // 페이지를 나가는 경우, 설정 값 초기화
+  resetFormState: () =>
+    set({
+      mode: null,
+      initialValues: null,
+      initialImgUrls: [],
+    }),
+}));


### PR DESCRIPTION
## 🔧 작업 내용

1. 작품 정보 수정 기능에서 initialValue값을 제외하고 모든 기능을 구현하였습니다.
- 이후, 상품 상세 페이지가 구현되면 상품 상세 정보 api 요청을 통해 initialValue값을 가져올 예정입니다.

2. `useProductRegisterPage` 커스텀 훅을 구현하였습니다.
- useProductRegisterPage 커스텀 훅을 통해 상품 등록/수정/임시저장 페이지에 접근해야합니다.
- 해당 훅을 사용하지 않고 해당 페이지에 접근하는 경우 error와 함께 메인페이지로 이동합니다.
- 임시저장 기능의 경우 아직 구현되지 않았습니다.
- 사용방법 (예시)
```ts
'use client';

import { useProductRegisterPage } from '@/hooks/useProductRegisterPage';

export default function Page() {
  const enterRegisterPage = useProductRegisterPage();

  return (
    <div className="mx-auto flex min-h-dvh items-center justify-center">
      <button
        onClick={() => enterRegisterPage.edit({ productId: 1116 })}
        className="cursor-pointer rounded-full bg-amber-300 p-5 text-white"
      >
        작품 수정 버튼
      </button>
    </div>
  );
}
```
