### PR TITLE
feat(detail): 상품 상세 페이지 수정 기능 연동

### DIFF
--- a/app/(routes)/products/[id]/_components/PatchAndDelete.tsx
+++ b/app/(routes)/products/[id]/_components/PatchAndDelete.tsx
@@ -6,6 +6,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { Button } from '@/components/ui/button';
 import { ROUTE_PATHS } from '@/constants/route-paths';
+import { useProductRegisterPage } from '@/hooks/useProductRegisterPage';
 import { deleteProduct } from '@/lib/apis/products.api';
 import { useUserSummary } from '@/lib/queries/useUserQueries';
 
@@ -15,8 +16,9 @@ interface PatchAndDeleteProps {
 }
 
 export default function PatchAndDelete({ itemId, isOwner }: PatchAndDeleteProps) {
-  const { data } = useUserSummary();
+  const enterRegisterPage = useProductRegisterPage();
 
+  const { data } = useUserSummary();
   const user = data?.result ?? null;
 
   const queryClient = useQueryClient();
@@ -34,7 +36,10 @@ export default function PatchAndDelete({ itemId, isOwner }: PatchAndDeleteProps)
     <>
       {user && isOwner && (
         <div className="mb-2.5 flex gap-5">
-          <Button className="text-custom-brand-primary h-auto bg-transparent p-0 shadow-none hover:cursor-pointer hover:bg-transparent hover:underline">
+          <Button
+            onClick={() => enterRegisterPage.edit(itemId)}
+            className="text-custom-brand-primary h-auto bg-transparent p-0 shadow-none hover:cursor-pointer hover:bg-transparent hover:underline"
+          >
             작품 수정하기
           </Button>
           <Button

--- a/hooks/useProductRegisterPage.ts
+++ b/hooks/useProductRegisterPage.ts
@@ -19,7 +19,7 @@ import { useProductRegisterForm } from '@/stores/useProductRegisterForm';
  */
 export function useProductRegisterPage() {
   const router = useRouter();
-  const { setMode, setInitialFormValues, setProductId } = useProductRegisterForm();
+  const { setMode, setInitialFormValues, setProductId, resetFormState } = useProductRegisterForm();
 
   const enterRegisterPage = {
     create: () => {
@@ -61,6 +61,7 @@ export function useProductRegisterPage() {
 
         router.push(ROUTE_PATHS.REGISTER_PRODUCT);
       } catch {
+        resetFormState();
         toast.error('잠시 후 다시 시도해주세요');
       }
     },


### PR DESCRIPTION
## 🔧 작업 내용

1. 커스텀 훅 `useProductRegisterPage`의 수정 기능을 상품 상세 기능 조회 API와 연동하여 초기값을 불러오도록 구현하였습니다.

2. 상품 상세 페이지의 수정 기능을 연동 하였습니다.
