### PR TITLE
feat(hooks): useScrapToggle 커스텀 훅 scrap count 추가 및 동작 변경

### DIFF
--- a/app/_components/product/ScrapButton.tsx
+++ b/app/_components/product/ScrapButton.tsx
@@ -11,13 +11,17 @@ interface ScrapButtonProps {
 }
 
 export default function ScrapButton({ product, hasScrapCount }: ScrapButtonProps) {
-  const { isScraped, toggleIsScraped } = useScrapToggle(product.id, product.scrap.isScrapped);
+  const { isScraped, scrapCount, toggleIsScraped } = useScrapToggle(
+    product.id,
+    product.scrap.isScrapped,
+    product.totalScraped
+  );
 
   return (
     <button onClick={toggleIsScraped} className="cursor-pointer">
       {isScraped ? <CardBookmarkFilledIcon /> : <CardBookmarkIcon />}
       {hasScrapCount && (
-        <p className="text-custom-background text-xs">{formatOverThousand(product.totalScraped)}</p>
+        <p className="text-custom-background text-xs">{formatOverThousand(scrapCount)}</p>
       )}
     </button>
   );

--- a/hooks/useScrapToggle.ts
+++ b/hooks/useScrapToggle.ts
@@ -8,6 +8,26 @@ import { useToggleProductScrap } from '@/lib/queries/useProductsQueries';
 
 import { useRequireAuth } from './useRequireAuth';
 
+export function useScrapToggle(
+  productId: number,
+  initialIsScraped: boolean,
+  initialScrapCount: number
+): {
+  isScraped: boolean;
+  scrapCount: number;
+  toggleIsScraped: () => void;
+};
+
+export function useScrapToggle(
+  productId: number,
+  initialIsScraped: boolean,
+  initialScrapCount?: undefined
+): {
+  isScraped: boolean;
+  scrapCount: undefined;
+  toggleIsScraped: () => void;
+};
+
 /**
  * 제품 스크랩 상태를 토글하는 커스텀 훅
  * @param productId - 제품 ID

--- a/hooks/useScrapToggle.ts
+++ b/hooks/useScrapToggle.ts
@@ -13,8 +13,13 @@ import { useRequireAuth } from './useRequireAuth';
  * @param productId - 제품 ID
  * @param initialIsScraped - 초기 스크랩 여부
  */
-export function useScrapToggle(productId: number, initialIsScraped: boolean) {
+export function useScrapToggle(
+  productId: number,
+  initialIsScraped: boolean,
+  initialScrapCount?: number
+) {
   const [isScraped, setIsScrapped] = useState(initialIsScraped); // UI 상태
+  const [scrapCount, setScrapCount] = useState(initialScrapCount); // UI 상태
   const [serverScrapState, setServerScrapState] = useState(initialIsScraped); // 서버와 동기화 된 상태
 
   const queryClient = useQueryClient();
@@ -37,18 +42,15 @@ export function useScrapToggle(productId: number, initialIsScraped: boolean) {
             predicate: (query) => query.queryKey[0] === QUERY_KEYS.products.all[0],
           });
         },
-        onError: () => {
-          // 요청 실패 시 서버 상태와 동일한 상태로 롤백
-          setIsScrapped(serverScrapState);
-        },
       }
     );
-  }, 500);
+  }, 300);
 
   const toggleScrapState = () => {
     const nextIsScrapped = !isScraped;
 
     setIsScrapped(nextIsScrapped);
+    setScrapCount((prev) => (prev !== undefined ? (nextIsScrapped ? prev + 1 : prev - 1) : prev));
 
     debouncedToggleScrap(nextIsScrapped);
   };
@@ -64,6 +66,7 @@ export function useScrapToggle(productId: number, initialIsScraped: boolean) {
 
   return {
     isScraped,
+    scrapCount,
     toggleIsScraped,
   };
 }


### PR DESCRIPTION
## 🔧 작업 내용

1. `useScrapToggle` 커스텀 훅의 scrap count 낙관적 업데이트를 추가하고 일부 동작을 변경 하였습니다.
- debounce delay 값을 500ms에서 300ms로 변경하였습니다.
- toggle api 요청 후 error 시에 롤백 기능을 제거 하였습니다. (UX 개선)
- 서버 배치 주기 변경으로 인해 scrap count 낙관적 업데이트 기능을 추가하였습니다.

2. 작가 피드 페이지에서 스크랩을 하는 경우에 count값이 올라가도록 하지는 않았습니다. (일단 제외)

3. 사용방법
- count값 낙관적 업데이트를 사용하지 않는 경우
```ts
const { isScraped, toggleIsScraped } = useScrapToggle(product.id, product.scrap.isScrapped);

return (
<button onClick={toggleIsScraped} className="cursor-pointer">
  {isScraped ? <CardBookmarkFilledIcon /> : <CardBookmarkIcon />}
  {hasScrapCount && (
    <p className="text-custom-background text-xs">{formatOverThousand(product.totalScraped)}</p>
  )}
</button>
)
```

- count값 낙관적 업데이트를 사용하는 경우
```ts
const { isScraped, scrapCount, toggleIsScraped } = useScrapToggle(
  product.id,
  product.scrap.isScrapped,
  product.totalScraped
);
  
return (
  <button onClick={toggleIsScraped} className="cursor-pointer">
    {isScraped ? <CardBookmarkFilledIcon /> : <CardBookmarkIcon />}
    {hasScrapCount && (
      <p className="text-custom-background text-xs">{formatOverThousand(scrapCount)}</p>
    )}
  </button>
);
```
