### PR TITLE
feat(register): 작품 등록 페이지 QA 반영 및 일부 동작 변경

### DIFF
--- a/app/(routes)/artists/products/register/_components/ProductInfoInputs.tsx
+++ b/app/(routes)/artists/products/register/_components/ProductInfoInputs.tsx
@@ -41,6 +41,7 @@ export default function ProductInfoInputs({ form }: ProductInfoInputsProps) {
                   <Input
                     className="placeholder:text-custom-gray-200 text-custom-gray-900 h-12 pr-12 pl-4.5 font-medium shadow-none placeholder:text-sm placeholder:font-medium"
                     placeholder="작품명을 입력해 주세요."
+                    maxLength={MAX_LENGTH.name}
                     {...field}
                   />
                   {field.value && (
@@ -124,7 +125,8 @@ export default function ProductInfoInputs({ form }: ProductInfoInputsProps) {
                 <div className="relative">
                   <Input
                     className="placeholder:text-custom-gray-200 text-custom-gray-900 h-12 pr-12 pl-4.5 font-medium shadow-none placeholder:text-sm placeholder:font-medium"
-                    placeholder="작품명을 입력해 주세요."
+                    placeholder="작품 재질을 입력해 주세요."
+                    maxLength={MAX_LENGTH.material}
                     {...field}
                   />
                   {field.value && (
@@ -161,7 +163,8 @@ export default function ProductInfoInputs({ form }: ProductInfoInputsProps) {
               <FormControl>
                 <Textarea
                   className="aria-invalid:border-input aria-invalid:focus-visible:ring-ring/50 placeholder:text-custom-gray-200 text-custom-gray-900 h-57 resize-none px-4.5 py-3.5 font-medium shadow-none placeholder:text-sm placeholder:font-medium"
-                  placeholder="작품 설명을 입력해 주세요."
+                  placeholder="작품에 대한 설명을 입력해 주세요."
+                  maxLength={MAX_LENGTH.description}
                   {...field}
                 />
               </FormControl>

--- a/app/(routes)/artists/products/register/_components/ProductInfoInputs.tsx
+++ b/app/(routes)/artists/products/register/_components/ProductInfoInputs.tsx
@@ -57,7 +57,7 @@ export default function ProductInfoInputs({ form }: ProductInfoInputsProps) {
               <div className="mt-1 flex items-center justify-between">
                 <FormMessage className="text-custom-status-negative text-xs font-semibold" />
                 <p className="flex-1 text-right text-xs">
-                  <span className="text-custom-status-notice">{field.value.trim().length}</span>/
+                  <span className="text-custom-status-notice">{field.value.length}</span>/
                   {MAX_LENGTH.name}
                 </p>
               </div>
@@ -141,7 +141,7 @@ export default function ProductInfoInputs({ form }: ProductInfoInputsProps) {
               <div className="mt-1 flex items-center justify-between">
                 <FormMessage className="text-custom-status-negative text-xs font-semibold" />
                 <p className="flex-1 text-right text-xs">
-                  <span className="text-custom-status-notice">{field.value?.trim().length}</span>/
+                  <span className="text-custom-status-notice">{field.value?.length}</span>/
                   {MAX_LENGTH.material}
                 </p>
               </div>
@@ -168,7 +168,7 @@ export default function ProductInfoInputs({ form }: ProductInfoInputsProps) {
               <div className="mt-1 flex items-center justify-between">
                 <FormMessage className="text-custom-status-negative text-xs font-semibold" />
                 <p className="flex-1 text-right text-xs">
-                  <span className="text-custom-status-notice">{field.value.trim().length}</span>/
+                  <span className="text-custom-status-notice">{field.value.length}</span>/
                   {MAX_LENGTH.description}
                 </p>
               </div>

--- a/app/(routes)/artists/products/register/_components/ProductRegisterForm.tsx
+++ b/app/(routes)/artists/products/register/_components/ProductRegisterForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { useRouter } from 'next/navigation';
@@ -23,6 +23,8 @@ export default function ProductRegisterForm() {
   const [productImages, setProductImages] = useState<(string | File)[]>(initialImgUrls);
   const [imageOrder, setImageOrder] = useState<string[]>(initialImgUrls);
   const [imageErrorMessage, setImageErrorMessage] = useState('');
+
+  const inputSectionRef = useRef<HTMLDivElement>(null);
 
   const [submitType, setSubmitType] = useState<'TEMP' | 'OPEN'>('OPEN');
 
@@ -152,7 +154,10 @@ export default function ProductRegisterForm() {
       return;
     }
 
-    if (!validateImages()) return;
+    if (!validateImages()) {
+      inputSectionRef.current?.scrollIntoView({ behavior: 'instant', block: 'start' });
+      return;
+    }
 
     const requestPayload = createRequestPayload(formValues);
 
@@ -178,7 +183,7 @@ export default function ProductRegisterForm() {
   return (
     <Form {...form}>
       <form className="w-full" onSubmit={form.handleSubmit(handleSubmit)}>
-        <div className="flex items-start gap-5">
+        <div ref={inputSectionRef} className="flex items-start gap-5">
           <ImageUploadInput
             images={productImages}
             onChangeImages={handleChangeImagesInput}

--- a/lib/schemas/productRegisterForm.schema.ts
+++ b/lib/schemas/productRegisterForm.schema.ts
@@ -42,9 +42,7 @@ export const productRegisterFormSchema = z
     title: z
       .string()
       .min(1, { message: '작품명을 입력해 주세요.' })
-      .refine((val) => val.replace(/\s/g, '').length <= MAX_LENGTH.name, {
-        message: '작품명은 공백 제외 40자 이내여야 합니다.',
-      }),
+      .max(MAX_LENGTH.name, { message: `작품명은 ${MAX_LENGTH.name}자 이내여야 합니다.` }),
 
     categoryType: z.string().min(1, { message: '카테고리를 선택해 주세요.' }),
 
@@ -52,16 +50,14 @@ export const productRegisterFormSchema = z
 
     material: z
       .string()
-      .optional()
-      .refine((val) => !val || val.replace(/\s/g, '').length <= MAX_LENGTH.material, {
-        message: '재질은 공백 제외 40자 이내여야 합니다.',
-      }),
+      .max(MAX_LENGTH.material, { message: `재질은 ${MAX_LENGTH.material}자 이내여야 합니다.` })
+      .optional(),
 
     description: z
       .string()
       .min(1, { message: '작품 설명을 입력해 주세요.' })
-      .refine((val) => val.replace(/(\s|\n)/g, '').length <= MAX_LENGTH.description, {
-        message: '작품 설명은 공백/줄바꿈 제외 400자 이내여야 합니다.',
+      .max(MAX_LENGTH.description, {
+        message: `작품 설명은 ${MAX_LENGTH.description}자 이내여야 합니다.`,
       }),
 
     priceType: z.enum(['fixed', 'inquiry'], { required_error: '거래 방식을 선택해 주세요.' }),


### PR DESCRIPTION
## 🔧 작업 내용

1. 이미지 입력이 누락되거나, 이미지 관련 에러가 발생한 경우 해당 에러 메세지가 위치한 곳으로 scroll하도록 변경하였습니다.
- 다른 입력의 경우 react-hook-form과 연동되어 자동으로 해당 동작을 하지만, image의 경우 별도로 관리되어 기능 추가

2. 작품 등록 입력 값 규칙을 수정하고, 입력 자체가 max length를 넘어가지 않도록 수정하였습니다.
- 규칙 : 공백 제외 → 공백 및 줄바꿈 포함

3. 잘못 된 placeholder를 변경하였습니다.
